### PR TITLE
Localized string export fixes

### DIFF
--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -142,7 +142,7 @@ namespace LocalizedStringPlugin
             {
                 FrostyTaskWindow.Show("Exporting Localized Strings", "", (task) =>
                 {
-                    using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create), false, true))
+                    using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create)))
                     {
                         int index = 0;
                         foreach (uint stringId in stringIds)

--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -151,6 +151,7 @@ namespace LocalizedStringPlugin
 
                             str = str.Replace("\r", "");
                             str = str.Replace("\n", " ");
+                            str = str.Replace("\"", "\"\"");
 
                             writer.WriteLine(stringId.ToString("X8") + ",\"" + str + "\"");
                             task.Update(progress: ((index++) / (double)stringIds.Count) * 100.0);


### PR DESCRIPTION
Fixes issues with the character encoding and improperly escaped quotation marks

## Before
![before](https://user-images.githubusercontent.com/40570798/155199240-0da254ca-ed75-4a85-8c78-ccbfd811d548.PNG)
![beforeQuotes](https://user-images.githubusercontent.com/40570798/155200805-5de5da3d-6101-49ea-9fd8-6b87f7bb279b.PNG)


## After
![after](https://user-images.githubusercontent.com/40570798/155199261-245a8df6-8344-4463-bd44-fe6f67b1e036.PNG)
![afterQuotes](https://user-images.githubusercontent.com/40570798/155200817-d2cbc62f-66c5-487c-9824-ba45ef45a397.PNG)