### PR TITLE
Fix for creating mvdb chache for games that dont have textureparams

### DIFF
--- a/FrostyPlugin/Viewport/MeshVariationDb.cs
+++ b/FrostyPlugin/Viewport/MeshVariationDb.cs
@@ -262,6 +262,11 @@ namespace Frosty.Core.Viewport
                                 writer.Write(mvMat.MaterialVariationAssetGuid);
                                 writer.Write(mvMat.MaterialVariationClassGuid);
                                 dynamic texParams = mvMat.TextureParameters;
+                                if (texParams == null)
+                                {
+                                    writer.Write(0);
+                                    continue;
+                                }
                                 writer.Write(texParams.Count);
                                 foreach (dynamic texParam in texParams)
                                 {


### PR DESCRIPTION
Some games like anthem that dont have texture parameters in the mvdb would crash when creating the cache, this fixes that