### PR TITLE
Type info cache for faster loading

### DIFF
--- a/FrostyPlugin/Sdk/ClassesSdkCreator.cs
+++ b/FrostyPlugin/Sdk/ClassesSdkCreator.cs
@@ -1246,6 +1246,10 @@ namespace Frosty.Core.Sdk
                 return false;
             }
 
+            // delete type info cache if there is one
+            if (File.Exists($"{App.FileSystem.CacheName}_typeinfo.cache"))
+                File.Delete($"{App.FileSystem.CacheName}_typeinfo.cache");
+
             return true;
         }
 


### PR DESCRIPTION
Creates a cache for loading the type info, if the sdk gets generated that cache gets deleted and regenerated when the editor gets launched.