### PR TITLE
File association support for project files

### DIFF
--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -11,6 +11,7 @@ using FrostySdk.IO;
 using Frosty.Core;
 using Frosty.Core.Controls;
 using FrostyCore;
+using System.Text;
 
 namespace FrostyEditor
 {
@@ -31,12 +32,23 @@ namespace FrostyEditor
         public static string Version = "";
         public static long StartTime;
 
+        public static bool OpenProject {
+            get => openProject;
+            set => openProject = value;
+        }
+
+        public static string LaunchArgs { get; private set; }
+
+        private static bool openProject;
+
         private FrostyConfiguration defaultConfig;
 
         public App()
         {
             Assembly entryAssembly = Assembly.GetEntryAssembly();
             Version = entryAssembly.GetName().Version.ToString();
+
+            Environment.CurrentDirectory = System.AppDomain.CurrentDomain.BaseDirectory;
 
             Logger = new FrostyLogger();
             Logger.Log("Frosty Editor v{0}", Version);
@@ -198,6 +210,13 @@ namespace FrostyEditor
 
                 App.InitDiscordRPC();
                 App.UpdateDiscordRPC("Loading...");
+            }
+
+            if (e.Args.Length > 0) {
+                string arg = e.Args[0];
+
+                openProject = true;
+                LaunchArgs = arg;
             }
         }
 

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -197,6 +197,29 @@ namespace FrostyEditor
                 }
             }
 
+            //check args to see if it is loading a project
+            if (e.Args.Length > 0) {
+                string arg = e.Args[0];
+                if (arg.Contains(".fbproject")) {
+                    openProject = true;
+                    LaunchArgs = arg;
+
+                    //get game profile from project file
+                    using (NativeReader reader = new NativeReader(new FileStream(arg, FileMode.Open, FileAccess.Read))) {
+                        if (reader.ReadULong() == 0x00005954534F5246) {
+                            reader.ReadUInt();
+                            string gameProfile = reader.ReadNullTerminatedString();
+                            try { 
+                                defaultConfig = new FrostyConfiguration(gameProfile); 
+                            }
+                            catch { 
+                                FrostyMessageBox.Show("There was an error when trying to load project using the profile: " + gameProfile, "Frosty Editor");
+                            }
+                        }
+                    }
+                }
+            }
+
             if (defaultConfig != null)
             {
                 // load profile
@@ -210,14 +233,6 @@ namespace FrostyEditor
 
                 App.InitDiscordRPC();
                 App.UpdateDiscordRPC("Loading...");
-            }
-
-            if (e.Args.Length > 0) {
-                string arg = e.Args[0];
-                if (arg.Contains(".fbproject")) {
-                    openProject = true;
-                    LaunchArgs = arg;
-                }
             }
         }
 

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -214,9 +214,10 @@ namespace FrostyEditor
 
             if (e.Args.Length > 0) {
                 string arg = e.Args[0];
-
-                openProject = true;
-                LaunchArgs = arg;
+                if (arg.Contains(".fbproject")) {
+                    openProject = true;
+                    LaunchArgs = arg;
+                }
             }
         }
 

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -307,6 +307,10 @@ namespace FrostyEditor
                     autoSaveTimer.Start();
                 }
             }
+
+            if (App.OpenProject) {
+                LoadProject(App.LaunchArgs, false);
+            }
         }
 
         private void logTextBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -126,14 +126,13 @@ namespace Frosty.Core.Windows
             AssetDisplayModuleInId = Config.Get<bool>("DisplayModuleInId", false);
             RememberChoice = Config.Get<bool>("UseDefaultProfile", false);
 
+            //Checks the registry for the current association instead of loading from config
             string KeyName = "frostyproject";
             string OpenWith = Assembly.GetEntryAssembly().Location;
 
             string openCommand = (string)Registry.CurrentUser.OpenSubKey("Software\\Classes\\" + KeyName).OpenSubKey("shell").OpenSubKey("open").OpenSubKey("command").GetValue("");
 
-            if (openCommand.Contains(OpenWith)) {
-                defaultInstallation = true;
-            }
+            if (openCommand.Contains(OpenWith)) defaultInstallation = true;
 
 
             //Language = new CustomComboData<string, string>(langs, langs) { SelectedIndex = langs.IndexOf(Config.Get<string>("Init", "Language", "English")) };
@@ -180,6 +179,7 @@ namespace Frosty.Core.Windows
 
             LocalizedStringDatabase.Current.Initialize();
 
+            //Make file association if checked
             if (defaultInstallation) {
                 string Extension = ".fbproject";
                 string KeyName = "frostyproject";

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -103,7 +103,7 @@ namespace Frosty.Core.Windows
         public bool RememberChoice { get; set; } = false;
 
         [Category("Editor")]
-        [DisplayName("Set Default Installation on Save")]
+        [DisplayName("Set as Default Installation")]
         [Description("Use this installation for .fbproject files.")]
         [EbxFieldMeta(EbxFieldType.Boolean)]
         public bool defaultInstallation { get; set; } = false;

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -179,7 +179,7 @@ namespace Frosty.Core.Windows
 
             LocalizedStringDatabase.Current.Initialize();
 
-            //Make file association if checked
+            //Create file association if enabled
             if (defaultInstallation) {
                 string Extension = ".fbproject";
                 string KeyName = "frostyproject";

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -14,6 +14,8 @@ using System.Reflection;
 using System.Windows;
 using System.Windows.Data;
 using FrostySdk;
+using Microsoft.Win32;
+using System.Runtime.InteropServices;
 
 namespace Frosty.Core.Windows
 {
@@ -100,6 +102,12 @@ namespace Frosty.Core.Windows
         [EbxFieldMeta(EbxFieldType.Boolean)]
         public bool RememberChoice { get; set; } = false;
 
+        [Category("Editor")]
+        [DisplayName("Set Default Installation on Save")]
+        [Description("Use this installation for .fbproject files.")]
+        [EbxFieldMeta(EbxFieldType.Boolean)]
+        public bool defaultInstallation { get; set; } = false;
+
         public override void Load()
         {
             List<string> langs = GetLocalizedLanguages();
@@ -118,6 +126,15 @@ namespace Frosty.Core.Windows
             AssetDisplayModuleInId = Config.Get<bool>("DisplayModuleInId", false);
             RememberChoice = Config.Get<bool>("UseDefaultProfile", false);
 
+            string KeyName = "frostyproject";
+            string OpenWith = Assembly.GetEntryAssembly().Location;
+
+            string openCommand = (string)Registry.CurrentUser.OpenSubKey("Software\\Classes\\" + KeyName).OpenSubKey("shell").OpenSubKey("open").OpenSubKey("command").GetValue("");
+
+            if (openCommand.Contains(OpenWith)) {
+                defaultInstallation = true;
+            }
+
 
             //Language = new CustomComboData<string, string>(langs, langs) { SelectedIndex = langs.IndexOf(Config.Get<string>("Init", "Language", "English")) };
 
@@ -134,6 +151,9 @@ namespace Frosty.Core.Windows
             //AssetDisplayModuleInId = Config.Get<bool>("Asset", "DisplayModuleInId", true);
             //RememberChoice = Config.Get<bool>("Init", "RememberChoice", false);
         }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
 
         public override void Save()
         {
@@ -159,6 +179,38 @@ namespace Frosty.Core.Windows
             Config.Save();
 
             LocalizedStringDatabase.Current.Initialize();
+
+            if (defaultInstallation) {
+                string Extension = ".fbproject";
+                string KeyName = "frostyproject";
+                string OpenWith = Assembly.GetEntryAssembly().Location;
+                string FileDescription = "Frosty Project";
+
+                RegistryKey BaseKey;
+                RegistryKey OpenMethod;
+                RegistryKey Shell;
+                RegistryKey CurrentUser;
+
+                BaseKey = Registry.CurrentUser.CreateSubKey("Software\\Classes\\" + Extension);
+                BaseKey.SetValue("", KeyName);
+
+                OpenMethod = Registry.CurrentUser.CreateSubKey("Software\\Classes\\" + KeyName);
+                OpenMethod.SetValue("", FileDescription);
+                OpenMethod.CreateSubKey("DefaultIcon").SetValue("", "\"" + OpenWith + "\",0");
+                Shell = OpenMethod.CreateSubKey("shell");
+                Shell.CreateSubKey("edit").CreateSubKey("command").SetValue("", "\"" + OpenWith + "\"" + " \"%1\"");
+                Shell.CreateSubKey("open").CreateSubKey("command").SetValue("", "\"" + OpenWith + "\"" + " \"%1\"");
+                BaseKey.Close();
+                OpenMethod.Close();
+                Shell.Close();
+
+                CurrentUser = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" + Extension, true);
+                CurrentUser.DeleteSubKey("UserChoice", false);
+                CurrentUser.Close();
+
+                // Tell explorer the file association has been changed
+                SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+            }
 
             //Config.Add("Autosave", "Enabled", AutosaveEnabled);
             //Config.Add("Autosave", "Period", AutosavePeriod);


### PR DESCRIPTION
- Option in Options to set file associations
- Skips prelaunch window & loads into the proper profile read from the project file
- Also sets the working directory to always be the location the Editor EXE is located