### PR TITLE
First pass for Manage ModData Window

### DIFF
--- a/FrostyModManager/FrostyModManager.csproj
+++ b/FrostyModManager/FrostyModManager.csproj
@@ -100,6 +100,9 @@
     <Compile Include="Windows\KeyPromptWindow.xaml.cs">
       <DependentUpon>KeyPromptWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Windows\ManageModDataWindow.xaml.cs">
+      <DependentUpon>ManageModDataWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\PrelaunchWindow2.xaml.cs">
       <DependentUpon>PrelaunchWindow2.xaml</DependentUpon>
     </Compile>
@@ -166,6 +169,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Page Include="Themes\Generic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\ManageModDataWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/FrostyModManager/Windows/MainWindow.xaml
+++ b/FrostyModManager/Windows/MainWindow.xaml
@@ -99,6 +99,7 @@
                     <MenuItem x:Name="exitMenuItem" Header="Exit" Click="exitMenuItem_Click"/>
                 </MenuItem>
                 <MenuItem x:Name="toolsMenuItem" Header="Tools" Height="22">
+                    <MenuItem x:Name="manageModData" Header="Manage ModData" Click="modDataMenuItem_Click"/>
                 </MenuItem>
                 <MenuItem Header="Help" Height="22">
                     <MenuItem x:Name="aboutMenuItem" Header="About Frosty Mod Manager" Click="aboutMenuItem_Click"/>

--- a/FrostyModManager/Windows/MainWindow.xaml.cs
+++ b/FrostyModManager/Windows/MainWindow.xaml.cs
@@ -1279,6 +1279,12 @@ namespace FrostyModManager
             win.ShowDialog();
         }
 
+        private void modDataMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            ManageModDataWindow win = new ManageModDataWindow();
+            win.ShowDialog();
+        }
+
         private void appliedModsList_SelectionChanged(object sender, SelectionChangedEventArgs e) => updateAppliedModButtons();
 
         private void updateAppliedModButtons()

--- a/FrostyModManager/Windows/ManageModDataWindow.xaml
+++ b/FrostyModManager/Windows/ManageModDataWindow.xaml
@@ -1,0 +1,42 @@
+﻿<!--
+    ManageModDataWindow
+    Author: Clonedelta
+-->
+<ctrl:FrostyDockableWindow x:Class="FrostyModManager.ManageModDataWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:FrostyModManager"
+        xmlns:ctrl="clr-namespace:Frosty.Controls;assembly=FrostyControls"
+        mc:Ignorable="d"
+        Title="Manage ModData" Height="250" Width="300"
+        ResizeMode="NoResize" WindowStartupLocation="CenterOwner">
+    <Grid Background="{StaticResource ListBackground}">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="30"/>
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Orientation="Vertical" Margin="4,7,4,4">
+            <TextBlock Grid.Column="0" Text="ModData Path:" Foreground="{StaticResource FontColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="16" Margin="2,1"/>
+            <TextBox IsReadOnly="True" Grid.Column="1" x:Name="modDataNameTextBox" BorderThickness="1" VerticalContentAlignment="Center" Height="22"/>
+            <TextBlock Text="Pack's ModData to Delete:" Foreground="{StaticResource FontColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="16" Margin="0,15,0,5"/>
+            <ComboBox x:Name="modDataComboBox" SelectedIndex="0" SelectedValuePath="Content" Height = "25" Width = "150" Margin = "0,0,0,20" VerticalContentAlignment="Center" >
+                <ComboBoxItem Content = "-- Select a Pack --"/>
+                <ComboBoxItem Content = "All ModData"/>
+            </ComboBox>
+            <Button Content="Delete Selected ModData Folder" HorizontalAlignment="center" Padding="10,2,10,2" Click="deleteModDataButton_Click"/>
+            <TextBlock x:Name="outputText" Foreground="{StaticResource FontColor}" HorizontalAlignment="Center" VerticalAlignment="top" Height="35"/>
+
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Column="0" x:Name="closeButton" Content="Close" Width="50" Height="22" HorizontalAlignment="Left" Click="closeButton_Click"/>
+        </Grid>
+    </Grid>
+</ctrl:FrostyDockableWindow>

--- a/FrostyModManager/Windows/ManageModDataWindow.xaml.cs
+++ b/FrostyModManager/Windows/ManageModDataWindow.xaml.cs
@@ -1,0 +1,136 @@
+﻿using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using Frosty.Controls;
+using Frosty.Core;
+using FrostySdk;
+
+namespace FrostyModManager
+{
+    /// <summary>
+    /// Author: Clonedelta
+    /// Class <c>ManageModDataWindow</c> handles the logic for deleting specified ModData folders. 
+    /// </summary>
+    public partial class ManageModDataWindow : FrostyDockableWindow
+    {
+        public ManageModDataWindow()
+        {
+            InitializeComponent();
+
+            // Draws the window in the center of the screen
+            Window mainWin = Application.Current.MainWindow;
+            if (mainWin != null)
+            {
+                double x = mainWin.Left + (mainWin.Width / 2.0);
+                double y = mainWin.Top + (mainWin.Height / 2.0);
+
+                Left = x - (Width / 2.0);
+                Top = y - (Height / 2.0);
+            }
+
+            // Draws the user's ModData directory on modDataNameTextBox
+            string modPath = getModDataPath();
+            modDataNameTextBox.Text = modPath;
+
+            if (!Directory.Exists(modPath + "\\ModData"))
+            {
+                Directory.CreateDirectory(modPath + "\\ModData"); // Done to avoid potential IO error on init
+            }
+
+            listPacks();
+        }
+
+        /// <summary>
+        /// Method <c>getModDataPath</c> Returns the path to the ModData folder.
+        /// </summary>
+        private string getModDataPath()
+        {
+            return Config.Get<string>("GamePath", "", ConfigScope.Game, ProfilesLibrary.ProfileName);
+        }
+
+        /// <summary>
+        /// Method <c>listPacks</c> lists the available packs in the ModData folder
+        /// </summary>
+        private void listPacks()
+        {
+            string modPath = getModDataPath();
+
+            // Grabs the packs currently in the ModData folder.
+            string[] modDataPacks = Directory.GetDirectories(@modPath + "\\ModData\\", "*", SearchOption.TopDirectoryOnly);
+
+            // Adds them to the ComboBox in the window.
+            // TODO: Find better way to get subdirectory names instead of parsing full path
+            foreach (string packNamePath in modDataPacks)
+            {
+                string[] packNamePathSplit = packNamePath.Split('\\');
+                string packName = packNamePathSplit[packNamePathSplit.Length - 1];
+                modDataComboBox.Items.Add(packName);
+            }
+        }
+
+        /// <summary>
+        /// Method <c>deleteModDataButton_Click</c> Delete operation for the selected ModData pack folder
+        /// </summary>
+        private void deleteModDataButton_Click(object sender, RoutedEventArgs e)
+        {
+            string modPath = getModDataPath();
+
+            try
+            {
+                // Checks which ComboBox item was selected
+                switch ((string)modDataComboBox.SelectedValue)
+                {
+                    case "-- Select a Pack --":
+                        outputText.Text = "Please select a Pack to delete.";
+                        outputText.Foreground = Brushes.Red;
+                        outputText.Visibility = Visibility.Visible;
+                        break;
+
+                    case "All ModData":
+                        Directory.Delete(modPath + "\\ModData", true);
+                        Directory.CreateDirectory(modPath + "\\ModData"); // Done to avoid potential IO error on init
+
+                        outputText.Text = "ModData Successfully Deleted.";
+                        outputText.Foreground = Brushes.Green;
+                        outputText.Visibility = Visibility.Visible;
+
+                        // Removes all options from the ComboBox
+                        for (int i = 2; i < modDataComboBox.Items.Count;)
+                        {
+                            modDataComboBox.Items.RemoveAt(i);
+                        }
+
+                        modDataComboBox.SelectedIndex = 0;
+                        break;
+
+                    default:
+
+                        Directory.Delete(modPath + "\\ModData\\" + modDataComboBox.SelectedItem, true);
+
+                        outputText.Text = modDataComboBox.SelectedItem + "'s ModData Successfully Deleted.";
+                        outputText.Foreground = Brushes.Green;
+                        outputText.Visibility = Visibility.Visible;
+
+                        modDataComboBox.Items.Remove(modDataComboBox.SelectedItem);
+                        modDataComboBox.SelectedIndex = 0;
+                        break;
+                }
+            }
+            catch (IOException)
+            {
+                outputText.Text = "Error deleting Pack!\nTry running Frosty as Administrator.";
+                outputText.Foreground = Brushes.Red;
+                outputText.Visibility = Visibility.Visible;
+            }
+        }
+
+        /// <summary>
+        /// Method <c>closeButton_Click</c> closes the window
+        /// </summary>
+        private void closeButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
Creates new window "ManageModDataWindow" under "Tools" to allow users to delete ModData from their Frosty instead of having to manually delete it.