### PR TITLE
[Editor] Cleaner Export Mod window

### DIFF
--- a/FrostyControls/Themes/Generic.xaml
+++ b/FrostyControls/Themes/Generic.xaml
@@ -155,6 +155,7 @@
     <!-- TextBox -->
     <Style x:Key="{x:Type TextBoxBase}" TargetType="{x:Type TextBoxBase}" BasedOn="{x:Null}">
         <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBackground}"/>
         <Setter Property="Background" Value="{StaticResource WindowBackground}"/>
         <Setter Property="Foreground" Value="{StaticResource FontColor}"/>
         <Setter Property="CaretBrush" Value="{StaticResource FontColor}"/>
@@ -170,7 +171,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}" >
-                    <Border x:Name="border" BorderBrush="{StaticResource ControlBackground}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
                         <ScrollViewer x:Name="PART_ContentHost" Focusable="False" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" Padding="0"/>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/FrostyEditor/Windows/ModSettingsWindow.xaml
+++ b/FrostyEditor/Windows/ModSettingsWindow.xaml
@@ -8,6 +8,16 @@
         mc:Ignorable="d"
         Title="Export Mod" Height="530" Width="600"
         ResizeMode="NoResize" WindowStartupLocation="CenterScreen" SnapsToDevicePixels="True">
+
+    <Window.Resources>
+        <Style x:Key="TextBoxValidate" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBoxBase}}">
+            <Style.Triggers>
+                <Trigger Property="Text" Value="">
+                    <Setter Property="BorderBrush" Value="Red"></Setter>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
     
     <Grid Background="{StaticResource WindowBackground}">
         <Grid.RowDefinitions>
@@ -17,25 +27,19 @@
 
         <Grid Background="{StaticResource ListBackground}">
             <DockPanel LastChildFill="True">
-                <Grid Margin="5" DockPanel.Dock="Top">
-                    <Label Content="Please fill out each of the following sections. Only the first section is mandatory." FontFamily="Global User Interface" HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="14"/>
-                </Grid>
-                
-                <Border DockPanel.Dock="Top" Background="{StaticResource ControlBackground}" Height="2"/>
-                
                 <Grid DockPanel.Dock="Top" Margin="5">
                     <StackPanel>
                         <DockPanel LastChildFill="True">
                             <Label Content="Title " FontFamily="Global User Interface" Width="75"/>
-                            <TextBox x:Name="modTitleTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1"/>
+                            <TextBox x:Name="modTitleTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1" Style="{StaticResource TextBoxValidate}"/>
                         </DockPanel>
                         <DockPanel LastChildFill="True">
                             <Label Content="Author " FontFamily="Global User Interface" Width="75"/>
-                            <TextBox x:Name="modAuthorTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1"/>
+                            <TextBox x:Name="modAuthorTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1" Style="{StaticResource TextBoxValidate}"/>
                         </DockPanel>
                         <DockPanel LastChildFill="True">
                             <Label Content="Version " FontFamily="Global User Interface" Width="75"/>
-                            <TextBox Grid.Column="1" x:Name="modVersionTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1"/>
+                            <TextBox Grid.Column="1" x:Name="modVersionTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1" Style="{StaticResource TextBoxValidate}"/>
                         </DockPanel>
                         <DockPanel LastChildFill="True">
                             <Label Content="Category " FontFamily="Global User Interface" Width="75"/>
@@ -46,7 +50,7 @@
                                 </Grid.ColumnDefinitions>
 
                                 <ComboBox Grid.Column="0" x:Name="modCategoryComboBox" Margin="1,1,0,1" SelectionChanged="modCategoryComboBox_SelectionChanged"/>
-                                <TextBox Grid.Column="1" x:Name="modCategoryTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1"/>
+                                <TextBox Grid.Column="1" x:Name="modCategoryTextBox" VerticalContentAlignment="Center" Text="Testing" Margin="1" BorderThickness="1" Style="{StaticResource TextBoxValidate}"/>
                             </Grid>
                         </DockPanel>
                     </StackPanel>


### PR DESCRIPTION
- Use red outline on textbox instead of window header to show required fields
- 'Expose' border brush in textbox to allow style to override
- (wannkunst's collection PR will also use the generic.xaml edits for his new window)

Before
![2022-05-08_15-30-32_FrostyEditor](https://user-images.githubusercontent.com/13797470/167312593-b76613ba-31e3-463a-bc27-f5e735787368.png)

After
![2022-05-08_15-13-44](https://user-images.githubusercontent.com/13797470/167312550-35db37bb-5c62-48c5-968d-0032bbeb19cf.png)
