### PR TITLE
[Plugins] Log id instead of string for invalid chars

### DIFF
--- a/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
+++ b/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
@@ -217,7 +217,6 @@ namespace FsLocalizationPlugin
                         if (index == -1)
                         {
                             App.Logger.LogWarning("Character not supported: " + b + " from string: " + key.ToString("X8"));
-                            /*throw new Exception("Character not supported: " + b + " from string: " + str);*/
                             continue;
                         }
 

--- a/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
+++ b/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
@@ -216,7 +216,7 @@ namespace FsLocalizationPlugin
                         int index = values.FindIndex((char a) => { return a.Equals(b); });
                         if (index == -1)
                         {
-                            App.Logger.LogWarning("Character not supported: " + b + " from string: " + str);
+                            App.Logger.LogWarning("Character not supported: " + b + " from string: " + key.ToString("X8"));
                             /*throw new Exception("Character not supported: " + b + " from string: " + str);*/
                             continue;
                         }


### PR DESCRIPTION
Logs the warning for a invalid character with just the character and the string id instead of the full string, to prevent crashing for certain strings.