### PR TITLE
Fix Battlefield 1 mesh imports

### DIFF
--- a/FrostyModManager/Windows/MainWindow.xaml
+++ b/FrostyModManager/Windows/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:localctrl="clr-namespace:FrostyModManager.Controls"
         xmlns:conv="clr-namespace:Frosty.Core.Converters;assembly=FrostyCore"
         mc:Ignorable="d"
-        Title="Frosty Mod Manager" Height="750" Width="1000"
+        Title="Frosty Mod Manager" Height="750" Width="1050"
         Icon="/FrostyModManager;component/AppIcon.ico"
         FrostyLoaded="FrostyWindow_FrostyLoaded" Closing="FrostyWindow_Closing" AllowDrop="True" Drop="FrostyWindow_Drop">
 

--- a/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
+++ b/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
@@ -1992,7 +1992,7 @@ namespace MeshSetPlugin
                     }
 
                     // MEC/BF1/SWBF2/BFV/Anthem/FIFA19/FIFA20/BFN/SWS
-                    else if (ProfilesLibrary.DataVersion == (int)ProfileVersion.MirrorsEdgeCatalyst || ProfilesLibrary.DataVersion == (int)ProfileVersion.Battlefield1 || ProfilesLibrary.DataVersion == (int)ProfileVersion.StarWarsBattlefrontII || ProfilesLibrary.DataVersion == (int)ProfileVersion.Fifa19 ||
+                    else if (ProfilesLibrary.DataVersion == (int)ProfileVersion.MirrorsEdgeCatalyst || ProfilesLibrary.DataVersion == (int)ProfileVersion.Battlefield5 || ProfilesLibrary.DataVersion == (int)ProfileVersion.StarWarsBattlefrontII || ProfilesLibrary.DataVersion == (int)ProfileVersion.Fifa19 ||
                              ProfilesLibrary.DataVersion == (int)ProfileVersion.Fifa20 || ProfilesLibrary.DataVersion == (int)ProfileVersion.StarWarsSquadrons)
                     {
                         // ushort/uint, can handle long lists so just put all bones into sections

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -1399,6 +1399,8 @@ namespace MeshSetPlugin.Resources
         private List<AxisAlignedBox> partBoundingBoxes = new List<AxisAlignedBox>();
         private List<LinearTransform> partTransforms = new List<LinearTransform>();
 
+        private byte[] unknownbfv;
+
         public MeshSet()
         {
         }
@@ -1596,7 +1598,7 @@ namespace MeshSetPlugin.Resources
 
             reader.Pad(16);
             if (ProfilesLibrary.DataVersion == (int)ProfileVersion.Battlefield5)
-                reader.ReadBytes(16);
+                unknownbfv = reader.ReadBytes(16);
 
             // lods
             for (int i = 0; i < lodCount; i++)
@@ -1855,6 +1857,10 @@ namespace MeshSetPlugin.Resources
             }
 
             writer.WritePadding(16);
+
+            if (ProfilesLibrary.DataVersion == (int)ProfileVersion.Battlefield5)
+                writer.Write(unknownbfv);
+
 
             Debug.Assert(writer.Position == HeaderSize);
 


### PR DESCRIPTION
Also has some small stuff for BFV but that won't get used in 1.0.6 so I don't think it's too big of a deal?
I'll make a separate PR for 1.0.7 with these same edits as it makes mesh imports work for BFV as well.