### PR TITLE
[Core] Fixed property grid filter crash

### DIFF
--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1060,10 +1060,6 @@ namespace Frosty.Core.Controls
                 FrostyPropertyGridItemFlags flags = FrostyPropertyGridItemFlags.None;
                 if (attributes.GetCustomAttribute<IsReferenceAttribute>() != null)
                     flags |= FrostyPropertyGridItemFlags.IsReference;
-
-                //object subDefValue = null;
-                //if (defValue != null)
-                //    subDefValue = pi.GetValue(defValue);
                 
                 object actualObject = value;
                 object actualDefaultValue = defValue;
@@ -1072,9 +1068,10 @@ namespace Frosty.Core.Controls
                     actualObject = additionalData;
                     actualDefaultValue = typeOverrideDefaultValue;
                 }
+                if (actualDefaultValue != null)
+                    actualDefaultValue = pi.GetValue(actualDefaultValue);
 
-                FrostyPropertyGridItemData subItem = new FrostyPropertyGridItemData(name, pi.Name, pi.GetValue(actualObject), pi.GetValue(actualDefaultValue), parent, flags) { Binding = new PropertyValueBinding(pi, actualObject) };
-                //FrostyPropertyGridItemData subItem = new FrostyPropertyGridItemData(name, pi.Name, pi.GetValue(value), subDefValue, parent, flags) {Binding = new PropertyValueBinding(pi, value)};
+                FrostyPropertyGridItemData subItem = new FrostyPropertyGridItemData(name, pi.Name, pi.GetValue(actualObject), actualDefaultValue, parent, flags) { Binding = new PropertyValueBinding(pi, actualObject) };
 
                 if (attributes.GetCustomAttribute<FrostySdk.Attributes.IsReadOnlyAttribute>() != null)
                     subItem.IsReadOnly = true;


### PR DESCRIPTION
Fixes a small oversight in the property grid that caused the editor to crash when searching for fields or GUIDs that are not present in the EBX.