### PR TITLE
[Schematics] Add wire cutter

### DIFF
--- a/Controls/Schematics/CommentNodeVisual.cs
+++ b/Controls/Schematics/CommentNodeVisual.cs
@@ -15,6 +15,8 @@ namespace LevelEditorPlugin.Controls
 
         private Brush colorBrush;
         private Pen colorPen;
+        private SolidColorBrush outlineBrush;
+        private Pen outlinePen;
         private List<BaseVisual> nodes;
 
         public CommentNodeVisual(CommentNodeData commentData, IEnumerable<BaseVisual> selectedVisuals, double x, double y) 
@@ -27,6 +29,8 @@ namespace LevelEditorPlugin.Controls
 
             colorBrush = new SolidColorBrush(Color.FromScRgb(1.0f, commentData.Color.x, commentData.Color.y, commentData.Color.z));
             colorPen = new Pen(colorBrush, 5.0);
+            outlineBrush = new SolidColorBrush(Color.FromScRgb(0.0f, 1.0f, 1.0f, 1.0f));
+            outlinePen = new Pen(outlineBrush, 2.5);
 
             UpdatePositionAndSize();
         }
@@ -57,7 +61,20 @@ namespace LevelEditorPlugin.Controls
         public override bool HitTest(Point mousePos)
         {
             Rect invalidZoneRect = new Rect(Rect.X + 5, Rect.Y + 20, Rect.Width - 10, Rect.Height - 25);
-            return !invalidZoneRect.Contains(mousePos);
+            bool hitTitle = !invalidZoneRect.Contains(mousePos);                              
+            return hitTitle;
+        }
+
+        public override bool OnMouseOver(Point mousePos)
+        {
+            outlineBrush.Opacity = 0.4;
+            return base.OnMouseOver(mousePos);
+        }
+
+        public override bool OnMouseLeave()
+        {
+            outlineBrush.Opacity = 0.0;
+            return base.OnMouseLeave();
         }
 
         public override void Move(Point newPos)
@@ -83,7 +100,17 @@ namespace LevelEditorPlugin.Controls
         public override void Render(SchematicsCanvas.DrawingContextState state)
         {
             colorPen.Thickness = 5.0 * state.Scale;
-            colorPen.Brush = (IsSelected) ? Brushes.PaleGoldenrod : colorBrush;
+            colorPen.Brush = colorBrush;
+
+            Rect rect = nodes[0].Rect;
+            for (int i = 1; i < nodes.Count; i++)
+            {
+                rect.Union(nodes[i].Rect);
+            }
+            Rect.X = rect.X - 10;
+            Rect.Y = rect.Y - 30;
+            Rect.Width = rect.Width + 20;
+            Rect.Height = rect.Height + 40;
 
             Rect outlineRect = new Rect(Rect.X + 2.5, Rect.Y + 2.5, Rect.Width - 5, Rect.Height - 5);
             Rect titleRect = new Rect(Rect.X, Rect.Y, Rect.Width, 20);
@@ -107,6 +134,12 @@ namespace LevelEditorPlugin.Controls
                     state.DrawingContext.DrawGlyphRun((luminance > 0.2) ? Brushes.Black : Brushes.White, titleGlyphRun);
                 }
             }
+
+            // selection outline
+            outlinePen.Thickness = 2.5 * state.Scale;
+            outlinePen.Brush = IsSelected ? Brushes.PaleGoldenrod : outlineBrush;
+            Rect selectedRect = new Rect(Rect.X - 1, Rect.Y - 1, Rect.Width + 2, Rect.Height + 2);
+            state.DrawingContext.DrawRectangle(null, outlinePen, state.TransformRect(selectedRect));
         }
 
         private void UpdatePositionAndSize()

--- a/Controls/Schematics/WireVisual.cs
+++ b/Controls/Schematics/WireVisual.cs
@@ -285,11 +285,16 @@ namespace LevelEditorPlugin.Controls
             Point b = (Target != null) ? Target.Rect.Location : mousePosition;
 
             Pen wirePen = null;
-            switch (WireType)
+            if (Source.IsSelected || Target.IsSelected)
+                wirePen = state.WireSelectedPen;
+            else
             {
-                case 0: wirePen = state.WireLinkPen; break;
-                case 1: wirePen = state.WireEventPen; break;
-                case 2: wirePen = state.WirePropertyPen; break;
+                switch (WireType)
+                {
+                    case 0: wirePen = state.WireLinkPen; break;
+                    case 1: wirePen = state.WireEventPen; break;
+                    case 2: wirePen = state.WirePropertyPen; break;
+                }
             }
 
             if (Source != null)

--- a/Controls/Schematics/WireVisual.cs
+++ b/Controls/Schematics/WireVisual.cs
@@ -12,6 +12,8 @@ namespace LevelEditorPlugin.Controls
 {
     public class WireVisual
     {
+        public GeometryGroup WireGeometry => geometry;
+
         public object Data;
         public BaseNodeVisual Source;
         public BaseNodeVisual.Port SourcePort;

--- a/Controls/SchematicsCanvas.cs
+++ b/Controls/SchematicsCanvas.cs
@@ -363,6 +363,12 @@ namespace LevelEditorPlugin.Controls
         private Point marqueeSelectionStart;
         private Point marqueeSelectionCurrent;
 
+        private bool isCuttingWire;
+        private Point wireCutStart;
+        private Point wireCutCurrent;
+        private List<WireVisual> wiresToCut = new List<WireVisual>();
+
+
         private FormattedText simulationText;
 
         private DrawingVisual debugLayerVisual;
@@ -717,6 +723,7 @@ namespace LevelEditorPlugin.Controls
             wirePropertyPen = new Pen(SchematicPropertyBrush, 2.0); wirePropertyPen.Freeze();
             wireHitTestPen = new Pen(Brushes.Transparent, 4.0); wireHitTestPen.Freeze();
             shortcutWirePen = new Pen(Brushes.WhiteSmoke, 2.0) { DashStyle = DashStyles.Dash }; shortcutWirePen.Freeze();
+            wireSelectedPen = new Pen(Brushes.PaleGoldenrod, 2.0); wireSelectedPen.Freeze();
             marqueePen = new Pen(Brushes.White, 2.0) { DashStyle = DashStyles.Dash }; marqueePen.Freeze();
             glowPen = new Pen(Brushes.Yellow, 5.0); glowPen.Freeze();
 
@@ -1072,6 +1079,24 @@ namespace LevelEditorPlugin.Controls
 
                     InvalidateVisual();
                 }
+                else if (isCuttingWire)
+                {
+                    wireCutCurrent = mousePos;
+                    MatrixTransform mat = GetWorldMatrix();
+                    //Point startPos = mat.Inverse.Transform(wireCutStart);
+                    //Point endPos = mat.Inverse.Transform(wireCutCurrent);
+
+                    // clear list to avoid cutting wires that were previously hovered over
+                    wiresToCut.Clear();
+                    foreach (WireVisual wire in wireVisuals)
+                    {
+                        LineGeometry wireCutLine = wire.WireGeometry.Children[0] as LineGeometry;
+                        if (intersect(wireCutStart, wireCutCurrent, wireCutLine.StartPoint, wireCutLine.EndPoint))
+                            wiresToCut.Add(wire);
+                    }
+
+                    InvalidateVisual();
+                }
             }
             else
             {
@@ -1117,6 +1142,17 @@ namespace LevelEditorPlugin.Controls
             }
 
             base.OnMouseMove(e);
+
+            bool ccw(Point A, Point B, Point C)
+            {
+                return (C.Y - A.Y) * (B.X - A.X) > (B.Y - A.Y) * (C.X - A.X);
+            }
+    
+            bool intersect(Point start1, Point end1, Point start2, Point end2)
+            {
+                return ccw(start1, start2, end2) != ccw(end1, start2, end2) && ccw(start1, end1, start2) != ccw(start1, end1, end2);
+            }
+    
         }
 
         protected override void OnMouseDown(MouseButtonEventArgs e)
@@ -1275,9 +1311,12 @@ namespace LevelEditorPlugin.Controls
                 else
                 {
                     Mouse.Capture(this);
-                    isMarqueeSelecting = hoveredNode == null;
+                    isMarqueeSelecting = hoveredNode == null && !Keyboard.IsKeyDown(Key.LeftAlt) && !isCuttingWire;
+                    isCuttingWire = hoveredNode == null && Keyboard.IsKeyDown(Key.LeftAlt) && !isMarqueeSelecting;
                     marqueeSelectionStart = mousePos;
                     marqueeSelectionCurrent = mousePos;
+                    wireCutStart = mousePos;
+                    wireCutCurrent = mousePos;
                 }
 
                 InvalidateVisual();
@@ -1420,6 +1459,37 @@ namespace LevelEditorPlugin.Controls
                     InvalidateVisual();
                     return;
                 }
+
+                if (isCuttingWire && e.ChangedButton == MouseButton.Left)
+                {
+                    isCuttingWire = false;
+                    foreach (WireVisual wire in wiresToCut)
+                    {
+                        BaseVisual sourceNode = (wire.Source is BaseVisual) ? (wire.Source as BaseVisual) : null;
+                        BaseVisual targetNode = (wire.Target is BaseVisual) ? (wire.Target as BaseVisual) : null;
+
+                        UndoContainer container = new UndoContainer("Delete Connection(s)");
+
+                        WireRemovedCommand?.Execute(new WireRemovedEventArgs(wire.Data,
+                                (wire.Source is NodeVisual) ? (wire.Source as NodeVisual).Entity : null,
+                                (wire.Target is NodeVisual) ? (wire.Target as NodeVisual).Entity : null, container));
+
+                        if (container.HasItems)
+                        {
+                            container.Add(new GenericUndoUnit("", o => InvalidateVisual(), o => { }));
+                            UndoManager.Instance.CommitUndo(container);
+                        }
+
+                        sourceNode.Update();
+                        targetNode.Update();
+                    }
+                    wiresToCut.Clear();
+
+                    Mouse.Capture(null);
+
+                    InvalidateVisual();
+                    return;
+                }
             }
 
             base.OnMouseUp(e);
@@ -1545,31 +1615,38 @@ namespace LevelEditorPlugin.Controls
 
         private void DrawSelectionRect(DrawingContext drawingContext)
         {
-            if (!isMarqueeSelecting)
+            if (!isMarqueeSelecting && !isCuttingWire)
                 return;
 
             MatrixTransform m = GetWorldMatrix();
 
-            double width = marqueeSelectionCurrent.X - marqueeSelectionStart.X;
-            double height = marqueeSelectionCurrent.Y - marqueeSelectionStart.Y;
-
-            if (width == 0 && height == 0)
-                return;
-
-            Point startPos = marqueeSelectionStart;
-
-            if (width <= 0)
+            if (isCuttingWire)
             {
-                width = marqueeSelectionStart.X - marqueeSelectionCurrent.X;
-                startPos.X = marqueeSelectionCurrent.X;
+                drawingContext.DrawLine(marqueePen, m.Transform(wireCutStart), m.Transform(wireCutCurrent));
             }
-            if (height <= 0)
+            else
             {
-                height = marqueeSelectionStart.Y - marqueeSelectionCurrent.Y;
-                startPos.Y = marqueeSelectionCurrent.Y;
-            }
+                double width = marqueeSelectionCurrent.X - marqueeSelectionStart.X;
+                double height = marqueeSelectionCurrent.Y - marqueeSelectionStart.Y;
 
-            drawingContext.DrawRectangle(null, marqueePen, new Rect(m.Transform(startPos), new Size(width * scale, height * scale)));
+                if (width == 0 && height == 0)
+                    return;
+
+                Point startPos = marqueeSelectionStart;
+
+                if (width <= 0)
+                {
+                    width = marqueeSelectionStart.X - marqueeSelectionCurrent.X;
+                    startPos.X = marqueeSelectionCurrent.X;
+                }
+                if (height <= 0)
+                {
+                    height = marqueeSelectionStart.Y - marqueeSelectionCurrent.Y;
+                    startPos.Y = marqueeSelectionCurrent.Y;
+                }
+
+                drawingContext.DrawRectangle(null, marqueePen, new Rect(m.Transform(startPos), new Size(width * scale, height * scale)));
+            }
         }
 
         private void UpdateVisibleNodes()

--- a/Controls/SchematicsCanvas.cs
+++ b/Controls/SchematicsCanvas.cs
@@ -320,6 +320,7 @@ namespace LevelEditorPlugin.Controls
         private Pen wirePropertyPen;
         private Pen wireHitTestPen;
         private Pen shortcutWirePen;
+        private Pen wireSelectedPen;
         private Pen marqueePen;
         private Pen glowPen;
 
@@ -370,6 +371,7 @@ namespace LevelEditorPlugin.Controls
             public Pen WirePropertyPen { get; private set; }
             public Pen WireHitTestPen { get; private set; }
             public Pen ShortcutWirePen { get; private set; }
+            public Pen WireSelectedPen { get; private set; }
             public Pen GlowPen { get; private set; }
 
             // Various Brushes
@@ -435,6 +437,7 @@ namespace LevelEditorPlugin.Controls
                 WirePropertyPen = owner.wirePropertyPen;
                 WireHitTestPen = owner.wireHitTestPen;
                 ShortcutWirePen = owner.shortcutWirePen;
+                WireSelectedPen = owner.wireSelectedPen;
                 GlowPen = owner.glowPen;
 
                 NodeTitleBackgroundBrush = new SolidColorBrush(Color.FromRgb(63, 63, 63));
@@ -688,6 +691,7 @@ namespace LevelEditorPlugin.Controls
             wirePropertyPen = new Pen(SchematicPropertyBrush, 2.0); wirePropertyPen.Freeze();
             wireHitTestPen = new Pen(Brushes.Transparent, 4.0); wireHitTestPen.Freeze();
             shortcutWirePen = new Pen(Brushes.WhiteSmoke, 2.0) { DashStyle = DashStyles.Dash }; shortcutWirePen.Freeze();
+            wireSelectedPen = new Pen(Brushes.PaleGoldenrod, 2.0); wireSelectedPen.Freeze();
             marqueePen = new Pen(Brushes.SlateGray, 2.0) { DashStyle = DashStyles.Dash }; marqueePen.Freeze();
             glowPen = new Pen(Brushes.Yellow, 5.0); glowPen.Freeze();
 
@@ -1020,7 +1024,7 @@ namespace LevelEditorPlugin.Controls
 
                     for (int i = selectedNodes.Count - 1; i >= 0; i--)
                     {
-                        if (!selectionRect.Contains(selectedNodes[i].Rect))
+                        if (!selectionRect.IntersectsWith(selectedNodes[i].Rect))
                         {
                             selectedNodes[i].IsSelected = false;
                             selectedNodes.RemoveAt(i);
@@ -1030,7 +1034,7 @@ namespace LevelEditorPlugin.Controls
 
                     foreach (BaseVisual node in nodeVisuals)
                     {
-                        if (selectionRect.Contains(node.Rect))
+                        if (selectionRect.IntersectsWith(node.Rect))
                         {
                             if (!selectedNodes.Contains(node))
                             {


### PR DESCRIPTION
Also includes some other minor changes:
- Auto resizing for the comment node
- Highlighting all connections to and from selected nodes
- Nodes are marquee selected upon intersection instead of having to be fully overlapped