### PR TITLE
[LevelEditor] Fixes for ObjectBlueprints and LevelData crashing

### DIFF
--- a/Editors/ViewModels/ComponentsViewModel.cs
+++ b/Editors/ViewModels/ComponentsViewModel.cs
@@ -60,12 +60,14 @@ namespace LevelEditorPlugin.Editors
         {
             entity = inEntity;
 
-            IComponentEntity componentEntity = entity as Entities.IComponentEntity;
-            foreach (Entity child in componentEntity.Components)
+            if (entity is Entities.IComponentEntity componentEntity)
             {
-                if (child is Entities.IComponentEntity)
+                foreach (Entity child in componentEntity.Components)
                 {
-                    children.Add(new ComponentWrapper(child));
+                    if (child is Entities.IComponentEntity)
+                    {
+                        children.Add(new ComponentWrapper(child));
+                    }
                 }
             }
         }

--- a/Render/TerrainRenderable.cs
+++ b/Render/TerrainRenderable.cs
@@ -331,8 +331,15 @@ namespace LevelEditorPlugin.Render
                     }
                 }
 
-                foreach (LayerData layer in layerDatas)
+                List<LayerData> tmpLayers = new List<LayerData>(layerDatas);
+                layerDatas.Clear();
+                foreach (LayerData layer in tmpLayers)
                 {
+                    if (layer.Node == null)
+                    {
+                        continue;
+                    }
+
                     if (layer.Node.data == null && layer.Node.nonTrivialSubtileCount != 0)
                     {
                         ushort hidx = htree.getNodeIndex(layer.Node.id);
@@ -359,6 +366,8 @@ namespace LevelEditorPlugin.Render
                             }
                         }
                     }
+
+                    layerDatas.Add(layer);
                 }
 
                 TerrainChunkRenderable chunk = new TerrainChunkRenderable(state, htree, hnode, mtree, layerDatas);


### PR DESCRIPTION
- fixes ObjectBlueprints crashing when opening them
- fixes certain LevelDatas crashing when rendering the terrain (might only be a temp fix)