### PR TITLE
2042 bpb changes

### DIFF
--- a/FrostySdk/Managers/Entries/EbxAssetEntry.cs
+++ b/FrostySdk/Managers/Entries/EbxAssetEntry.cs
@@ -13,7 +13,7 @@ namespace FrostySdk.Managers.Entries
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.Battlefield2042) &&
                     (base.Name.Contains("cd_") || base.Name.Contains("md_")))
                 {
-                    return $"Bundles/{base.Name}";
+                    return $"win32/{base.Name}";
                 }
 
                 return base.Name;

--- a/FrostySdk/Managers/Entries/ResAssetEntry.cs
+++ b/FrostySdk/Managers/Entries/ResAssetEntry.cs
@@ -83,6 +83,20 @@ namespace FrostySdk.Managers.Entries
     {
         public override string Type => ((ResourceType)ResType).ToString();
         public override string AssetType => "res";
+        public override string Name
+        {
+            get
+            {
+                // TODO: @techdebt find better method to move blueprint bundles to sub-folder, this will most likely break writing.
+                if (ProfilesLibrary.IsLoaded(ProfileVersion.Battlefield2042) &&
+                    (base.Name.Contains("cd_") || base.Name.Contains("md_")))
+                {
+                    return $"win32/{base.Name}";
+                }
+
+                return base.Name;
+            }
+        }
 
         public ulong ResRid;
         public uint ResType;


### PR DESCRIPTION
renamed the folder they are moved to from Bundles to win32 to be in line with some other FB games and the actual bundle naming scheme and also copy over the "fix" to res entries as well so the chunk/res explorer also gets the change.