### PR TITLE
undo res change

### DIFF
--- a/FrostySdk/Managers/Entries/ResAssetEntry.cs
+++ b/FrostySdk/Managers/Entries/ResAssetEntry.cs
@@ -83,20 +83,6 @@ namespace FrostySdk.Managers.Entries
     {
         public override string Type => ((ResourceType)ResType).ToString();
         public override string AssetType => "res";
-        public override string Name
-        {
-            get
-            {
-                // TODO: @techdebt find better method to move blueprint bundles to sub-folder, this will most likely break writing.
-                if (ProfilesLibrary.IsLoaded(ProfileVersion.Battlefield2042) &&
-                    (base.Name.Contains("cd_") || base.Name.Contains("md_")))
-                {
-                    return $"win32/{base.Name}";
-                }
-
-                return base.Name;
-            }
-        }
 
         public ulong ResRid;
         public uint ResType;


### PR DESCRIPTION
bringing over the ebx stuff to res for blueprint bundles in 2042 broke pretty much everything that depended on resources that gets them through the path/name so undoing that for now