### PR TITLE
[MeshSetPlugin] Fixes issue with importing over rigid meshes (1.0.6.2)

### DIFF
--- a/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
+++ b/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
@@ -2540,6 +2540,17 @@ namespace MeshSetPlugin
                             ushort[] finalBoneIndices = vertex.GetValue<ushort[]>("BoneIndices");
                             byte[] finalBoneWeights = vertex.GetValue<byte[]>("BoneWeights");
 
+                            // for some reason some rigid meshes have bone indices and weights
+                            // so we just make them all 0
+                            if (finalBoneIndices == null)
+                            {
+                                finalBoneIndices = new ushort[8];
+                            }
+                            if (finalBoneWeights == null)
+                            {
+                                finalBoneWeights = new byte[8];
+                            }
+
                             int currentStride = 0;
                             foreach (GeometryDeclarationDesc.Element elem in meshSection.GeometryDeclDesc[0].Elements)
                             {


### PR DESCRIPTION
- Fixes issue where importing over rigid meshes crashes, bc they have bone indices and weights for some reason