### PR TITLE
changed ToLower to ToLowerInvariant

### DIFF
--- a/FrostyPlugin/IO/FrostyModReader.cs
+++ b/FrostyPlugin/IO/FrostyModReader.cs
@@ -29,7 +29,7 @@ namespace Frosty.Core.IO
             dataCount = ReadInt();
 
             string profileName = ReadSizedString(ReadByte());
-            if (profileName.ToLower() != ProfilesLibrary.ProfileName.ToLower())
+            if (profileName.ToLowerInvariant() != ProfilesLibrary.ProfileName.ToLowerInvariant())
                 return;
 
             GameVersion = ReadInt();


### PR DESCRIPTION
since `ToLower()` is locale sensitive, it can cause issues in non-English systems. for example in my case, in Windows 11 Turkish version, `"StarWarsBattlefrontII".ToLower()` evaluates to `"starwarsbattlefrontıı"`, which causes the check to fail. some old mods I have come across have "StarWarsBattlefrontII" in the `.fbmod` file, although newer have "starwarsbattlefrontii", which doesn't cause any issues.

ideally _all_ occurrences of ToLower should be replaced, but this is the most problematic one (at least for me).