### PR TITLE
[BiowareLocalizationPlugin] Fix crash in editor when loading test resources.

### DIFF
--- a/Plugins/BiowareLocalizationPlugin/LocalizedResources/LocalizedStringResource.cs
+++ b/Plugins/BiowareLocalizationPlugin/LocalizedResources/LocalizedStringResource.cs
@@ -430,16 +430,29 @@ namespace BiowareLocalizationPlugin.LocalizedResources
         /// <returns></returns>
         public List<string> GetDefaultDeclinatedAdjective(uint adjectiveId)
         {
-            List<string> adjectiveStrings = new List<string>(DragonAgeDeclinatedCraftingNames.NumberOfDeclinations);
+            int numberOfDeclinations = DragonAgeDeclinatedCraftingNames.NumberOfDeclinations;
+            List<string> adjectiveStrings = new List<string>(numberOfDeclinations);
 
             int i = 0;
             foreach (LocalizedString entry in DragonAgeDeclinatedCraftingNames.GetDeclinatedAdjective(adjectiveId))
             {
-                if (entry != null)
-                {
-                    adjectiveStrings.Insert(i, entry.Value);
-                }
+
+                string value = entry?.Value;
+                adjectiveStrings.Add(value);
                 i++;
+            }
+
+            if(i< numberOfDeclinations)
+            {
+                int missingNo = numberOfDeclinations - i;
+                for(int j = 0; j< missingNo; j++)
+                {
+                    adjectiveStrings.Add(null);
+                }
+            }
+            else if( i > numberOfDeclinations)
+            {
+                App.Logger.LogWarning("The requested resource <{0}> contains more than the stated number of <{1}> declinations for adjectiveId <{2}>!", Name, numberOfDeclinations, adjectiveId);
             }
 
             return adjectiveStrings;

--- a/Plugins/BiowareLocalizationPlugin/Properties/AssemblyInfo.cs
+++ b/Plugins/BiowareLocalizationPlugin/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Windows;
 
 [assembly: PluginDisplayName("Bioware Localization Plugin")]
 [assembly: PluginAuthor("GalaxyMan2015 and KrrKs")]
-[assembly: PluginVersion("1.1.1.0")]
+[assembly: PluginVersion("1.1.1.1")]
 [assembly: PluginValidForProfile((int)ProfileVersion.DragonAgeInquisition)]
 [assembly: PluginValidForProfile((int)ProfileVersion.MassEffectAndromeda)]
 [assembly: PluginValidForProfile((int)ProfileVersion.Anthem)]


### PR DESCRIPTION
Fix crash when retrieving adjectives with missing declination values found in non english localization test resources.