### PR TITLE
[BiowareLocalizationPlugin] Fix crash in Localization Editor

### DIFF
--- a/Plugins/BiowareLocalizationPlugin/LocalizedResources/LocalizedStringResource.cs
+++ b/Plugins/BiowareLocalizationPlugin/LocalizedResources/LocalizedStringResource.cs
@@ -429,16 +429,29 @@ namespace BiowareLocalizationPlugin.LocalizedResources
         /// <returns></returns>
         public List<string> GetDefaultDeclinatedAdjective(uint adjectiveId)
         {
-            List<string> adjectiveStrings = new List<string>(DragonAgeDeclinatedCraftingNames.NumberOfDeclinations);
+            int numberOfDeclinations = DragonAgeDeclinatedCraftingNames.NumberOfDeclinations;
+            List<string> adjectiveStrings = new List<string>(numberOfDeclinations);
 
             int i = 0;
             foreach (LocalizedString entry in DragonAgeDeclinatedCraftingNames.GetDeclinatedAdjective(adjectiveId))
             {
-                if (entry != null)
-                {
-                    adjectiveStrings.Insert(i, entry.Value);
-                }
+
+                string value = entry?.Value;
+                adjectiveStrings.Add(value);
                 i++;
+            }
+
+            if(i< numberOfDeclinations)
+            {
+                int missingNo = numberOfDeclinations - i;
+                for(int j = 0; j< missingNo; j++)
+                {
+                    adjectiveStrings.Add(null);
+                }
+            }
+            else if( i > numberOfDeclinations)
+            {
+                App.Logger.LogWarning("The requested resource <{0}> contains more than the stated number of <{1}> declinations for adjectiveId <{2}>!", Name, numberOfDeclinations, adjectiveId);
             }
 
             return adjectiveStrings;

--- a/Plugins/BiowareLocalizationPlugin/Properties/AssemblyInfo.cs
+++ b/Plugins/BiowareLocalizationPlugin/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Windows;
 
 [assembly: PluginDisplayName("Bioware Localization Plugin")]
 [assembly: PluginAuthor("GalaxyMan2015 and KrrKs")]
-[assembly: PluginVersion("1.1.1.0")]
+[assembly: PluginVersion("1.1.1.1")]
 [assembly: PluginValidForProfile((int)ProfileVersion.DragonAgeInquisition)]
 [assembly: PluginValidForProfile((int)ProfileVersion.MassEffectAndromeda)]
 [assembly: PluginValidForProfile((int)ProfileVersion.Anthem)]


### PR DESCRIPTION
Same as the previous PR for 1.0.7 - fix crash on null adjectives encountered in DAI GlobalTestTranslated resources.