### PR TITLE
LaunchPlatformPlugin: kill platform processes enabled by new option

### DIFF
--- a/Plugins/LaunchPlatformPlugin/Actions/LaunchExecutionAction.cs
+++ b/Plugins/LaunchPlatformPlugin/Actions/LaunchExecutionAction.cs
@@ -91,8 +91,11 @@ namespace LaunchPlatformPlugin.Actions
                 // get platform path
                 selectedPlatform.Path = FindPlatformPath(selectedPlatform.RegistryKey, selectedPlatform.RegistryValue) + selectedPlatform.AdditionalExecutablePath;
 
-                // kill all the other platform processes
+                // kill all platform processes
+                if (Config.Get("PlatformLaunchingKill", true, ConfigScope.Game))
+                {
                 KillPlatformProcesses();
+                }
 
                 // origin doesn't need these modifications to launch with mods
                 if (platform != LaunchPlatform.Origin)

--- a/Plugins/LaunchPlatformPlugin/Actions/LaunchExecutionAction.cs
+++ b/Plugins/LaunchPlatformPlugin/Actions/LaunchExecutionAction.cs
@@ -94,7 +94,7 @@ namespace LaunchPlatformPlugin.Actions
                 // kill all platform processes
                 if (Config.Get("PlatformLaunchingKill", true, ConfigScope.Game))
                 {
-                KillPlatformProcesses();
+                    KillPlatformProcesses();
                 }
 
                 // origin doesn't need these modifications to launch with mods
@@ -188,7 +188,7 @@ namespace LaunchPlatformPlugin.Actions
 
         private Process WaitForProcess(string name, CancellationToken cancelToken)
         {
-            Process gameProcess = null;
+            Process awaitedProcess = null;
             while (true)
             {
                 cancelToken.ThrowIfCancellationRequested();
@@ -206,7 +206,7 @@ namespace LaunchPlatformPlugin.Actions
                         FileInfo fi = new FileInfo(processFilename);
                         if (fi.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            gameProcess = process;
+                            awaitedProcess = process;
                             break;
                         }
                     }
@@ -215,12 +215,12 @@ namespace LaunchPlatformPlugin.Actions
                     }
                 }
 
-                if (gameProcess != null)
+                if (awaitedProcess != null)
                 {
-                    while (gameProcess.MainWindowHandle == IntPtr.Zero)
+                    while (awaitedProcess.MainWindowHandle == IntPtr.Zero)
                         System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1));
 
-                    return gameProcess;
+                    return awaitedProcess;
                 }
             }
         }

--- a/Plugins/LaunchPlatformPlugin/Options/LaunchOptions.cs
+++ b/Plugins/LaunchPlatformPlugin/Options/LaunchOptions.cs
@@ -38,18 +38,26 @@ namespace LaunchPlatformPlugin.Options
         [DependsOn("PlatformLaunchingEnabled")]
         public CustomComboData<string, string> Platform { get; set; }
 
+        [Category("General")]
+        [Description("Kill platform processes before launch if enabled.")]
+        [DisplayName("Kill platform processes before launch")]
+        [EbxFieldMeta(FrostySdk.IO.EbxFieldType.Boolean)]
+        public bool PlatformLaunchingKill { get; set; } = true;
+
         public override void Load()
         {
             List<string> platforms = Enum.GetNames(typeof(LaunchPlatform)).ToList();
             Platform = new CustomComboData<string, string>(platforms, platforms) { SelectedIndex = platforms.IndexOf(Config.Get<string>("Platform", "Origin", ConfigScope.Game))};
 
             PlatformLaunchingEnabled = Config.Get("PlatformLaunchingEnabled", false, ConfigScope.Game);
+            PlatformLaunchingKill = Config.Get("PlatformLaunchingKill", true, ConfigScope.Game);
         }
 
         public override void Save()
         {
             Config.Add("Platform", Platform.SelectedName, ConfigScope.Game);
             Config.Add("PlatformLaunchingEnabled", PlatformLaunchingEnabled, ConfigScope.Game);
+            Config.Add("PlatformLaunchingKill", PlatformLaunchingKill, ConfigScope.Game);
         }
     }
 }


### PR DESCRIPTION
When restarting the game alot to mod in Frosty Editor, it was getting [really annoying](https://i.imgur.com/WFskEzw.png) having EA Desktop and Steam restart every launch. This request adds a option to the plugin to toggle whether the user wants platform processes to be killed on launch or not.