### PR TITLE
[Controls & Editor] Fix multi-line text pasting in CString fields, add additional command line options setting to editor

### DIFF
--- a/FrostyControls/Themes/Generic.xaml
+++ b/FrostyControls/Themes/Generic.xaml
@@ -3030,12 +3030,12 @@
                                           VerticalScrollBarVisibility="Hidden"
                                           Padding="0"
                                           Visibility="Hidden" />
-                            <TextBlock x:Name="PART_EllipsedText"
+                            <TextBox x:Name="PART_EllipsedText"
                                        Margin="2,0,0,0"
                                        VerticalAlignment="Center"
                                        Text="{Binding Path=Text, RelativeSource={RelativeSource AncestorType={x:Type TextBox}}}"
                                        Foreground="{TemplateBinding Foreground}"
-                                       TextTrimming="CharacterEllipsis"
+                                       AcceptsReturn="True"
                                        TextWrapping="NoWrap"
                                        Focusable="True"
                                        Cursor="IBeam" />

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -401,7 +401,7 @@ namespace FrostyEditor
             ModSettings editorSettings = new ModSettings { Title = "Editor Mod", Author = "Frosty Editor", Version = "1", Category = "Editor" };
 
             // apply mod
-            string additionalArgs = "";
+            string additionalArgs = Config.Get<string>("CommandLineArgs", "", ConfigScope.Game) + " ";
             FrostyModExecutor executor = new FrostyModExecutor();
 
             // Set pack
@@ -428,7 +428,7 @@ namespace FrostyEditor
                         cancelToken.Token.ThrowIfCancellationRequested();
 
                         task.Update("");
-                        executor.Run(App.FileSystem, cancelToken.Token, task.TaskLogger, $"Mods/{ProfilesLibrary.ProfileName}/", App.SelectedPack, additionalArgs, modPaths.ToArray());
+                        executor.Run(App.FileSystem, cancelToken.Token, task.TaskLogger, $"Mods/{ProfilesLibrary.ProfileName}/", App.SelectedPack, additionalArgs.Trim(), modPaths.ToArray());
 
                         foreach (var executionAction in App.PluginManager.ExecutionActions)
                             executionAction.PostLaunchAction(task.TaskLogger, PluginManagerType.Editor, cancelToken.Token);

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -126,6 +126,12 @@ namespace Frosty.Core.Windows
         [Editor(typeof(FrostyLocalizationLanguageDataEditor))]
         public CustomComboData<string, string> MaxCasFileSize { get; set; }
 
+        [Category("General")]
+        [DisplayName("Command Line Arguments")]
+        [Description("Command line arguments to run on launch.")]
+        [EbxFieldMeta(EbxFieldType.Boolean)]
+        public string CommandLineArgs { get; set; } = "";
+
         public override void Load()
         {
             List<string> langs = GetLocalizedLanguages();
@@ -150,6 +156,8 @@ namespace Frosty.Core.Windows
             List<string> sizes = new List<string>() { "1GB", "512MB", "256MB" };
             MaxCasFileSize = new CustomComboData<string, string>(sizes, sizes);
             MaxCasFileSize.SelectedIndex = sizes.IndexOf(Config.Get<string>("MaxCasFileSize", "1GB"));
+
+            CommandLineArgs = Config.Get<string>("CommandLineArgs", "", ConfigScope.Game);
 
             //Language = new CustomComboData<string, string>(langs, langs) { SelectedIndex = langs.IndexOf(Config.Get<string>("Init", "Language", "English")) };
 
@@ -185,6 +193,8 @@ namespace Frosty.Core.Windows
             Config.Add("UpdateCheckPrerelease", UpdateCheckPrerelease);
 
             Config.Add("MaxCasFileSize", MaxCasFileSize.SelectedName);
+
+            Config.Add("CommandLineArgs", CommandLineArgs, ConfigScope.Game);
 
             if (RememberChoice)
                 Config.Add("DefaultProfile", ProfilesLibrary.ProfileName);


### PR DESCRIPTION
unsure what this change will do besides fixing multi-line input
also ported the additional command line argument stuff from the manager