### PR TITLE
Fix Service not found error on Scanning of Games

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,38 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "2.0.0" ]
+  pull_request:
+    branches: [ "2.0.0" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build FrostySdk
+      run: |
+        cd FrostySdk
+        dotnet build --no-restore
+    - name: Build FrostySdkTest
+      run: |
+        cd FrostySdkTest
+        dotnet build --no-restore
+    - name: Build FrostyModSupport
+      run: |
+        cd FrostyModSupport
+        dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
@@ -192,6 +192,7 @@ namespace FrostyModManager.Windows
         {
             foreach (string subKeyName in subKey.GetSubKeyNames())
             {
+                if (subKeyName == "Perflib") continue;
                 try
                 {
                     IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount);


### PR DESCRIPTION
This fixes an the ,,The service cannot be started,, error on the scanning of Games, when the user doesnt have a working perfmon install.
The reason as to why it does it, lies in the Perfmon/009 Registry key.
After compiling with this fix, one is able to normal scan for games and use the app normally.
The fix can also be downported to 1.0.6.3, which you can see me do here, as i wont be PRing this for the sake of not spamming.
https://github.com/CadeEvs/FrostyToolsuite/commit/699c16968221238c9217bab187240f0945da18f2