### PR TITLE
Fix Service not found error on Scanning of Games

### DIFF
--- a/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
@@ -157,9 +157,9 @@ namespace FrostyEditor.Windows
                 {
                     IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount);
                 }
-                catch (System.Security.SecurityException)
+                catch (System.Exception)
                 {
-                    // do nothing
+                    continue;
                 }
             }
 

--- a/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
@@ -269,14 +269,13 @@ namespace FrostyModManager.Windows
         {
             foreach (string subKeyName in subKey.GetSubKeyNames())
             {
-                if(subKeyName == "Perflib") continue;
                 try
                 {
                     IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount);
                 }
-                catch (System.Security.SecurityException)
+                catch (System.Exception)
                 {
-                    // do nothing
+                    continue;
                 }
             }
 

--- a/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyModManager/Windows/PrelaunchWindow2.xaml.cs
@@ -269,6 +269,7 @@ namespace FrostyModManager.Windows
         {
             foreach (string subKeyName in subKey.GetSubKeyNames())
             {
+                if(subKeyName == "Perflib") continue;
                 try
                 {
                     IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount);


### PR DESCRIPTION
This fixes an the ,,The service cannot be started,, error on the scanning of Games, when the user doesnt have a working perfmon install.
The reason as to why it does it, lies in the Perfmon/009 Registry key.
After compiling with this fix, one is able to normal scan for games and use the app normally.
As to why not make it inside of the try catch is, because the try catch itself couldnt catch this.
This is the reason of this PR in the first place.
I wouldnt be here, if the try catch worked.

Have a nice day.