### PR TITLE
Copy texture params into duped mesh for swbf2

### DIFF
--- a/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
+++ b/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
@@ -228,7 +228,6 @@ namespace DuplicationPlugin
                                 if (mvm.MaterialVariationClassGuid == guid.ExportedGuid) //If it has the same guid
                                 {
                                     // We then use its texture params as the texture params in the variation
-                                    // We then use its texture params as the texture params in the variation
                                     foreach (dynamic texParam in (dynamic)mvm.TextureParameters)
                                     {
                                         matProperties.Shader.TextureParameters.Add(texParam);


### PR DESCRIPTION
We need to copy the texture params from a MVDB entry into the texture params of the duped mesh for swbf2, so thats what this adds(also changes the stuff to do that for object variations)