### PR TITLE
[Editor] Fix inconsistent context menu icon colors

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -228,7 +228,7 @@ namespace FrostyEditor
                 MenuItem contextMenuItem = new MenuItem
                 {
                     Header = contextItemExtension.ContextItemName,
-                    Icon = new Image() { Source = contextItemExtension.Icon, Opacity = 0.5 },
+                    Icon = new Image() { Source = contextItemExtension.Icon },
                     Command = contextItemExtension.ContextItemClicked
                 };
                 dataExplorer.AssetContextMenu.Items.Add(contextMenuItem);


### PR DESCRIPTION
Makes the plugin context menu icons have the same transparency as the base ones (basically what #108 also did)
Before:
![image](https://github.com/CadeEvs/FrostyToolsuite/assets/13797470/d3b920bf-3288-4394-af06-4672664c8e91)

After:
![image](https://github.com/CadeEvs/FrostyToolsuite/assets/13797470/42a7fb58-b732-4d47-a5e5-2c5dda9ec664)

