### PR TITLE
Math expressions in number textboxes

### DIFF
--- a/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
+++ b/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
@@ -28,10 +28,52 @@ namespace Frosty.Core.Controls.Editors
                 if (strValue == "" || strValue == null)
                     strValue = "0";
 
-                if (valueType == typeof(sbyte)) return sbyte.Parse(strValue);
-                else if (valueType == typeof(byte)) return byte.Parse(strValue);
-                else if (valueType == typeof(short)) return short.Parse(strValue);
-                else if (valueType == typeof(ushort)) return ushort.Parse(strValue);
+                if (valueType == typeof(sbyte))
+                {
+                    if (sbyte.TryParse(strValue, out sbyte result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (sbyte)mathResult;
+                    }
+                }
+                else if (valueType == typeof(byte))
+                {
+                    if (byte.TryParse(strValue, out byte result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (byte)mathResult;
+                    }
+                }
+
+                else if (valueType == typeof(short))
+                {
+                    if (short.TryParse(strValue, out short result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (short)mathResult;
+                    }
+                }
+                else if (valueType == typeof(ushort))
+                {
+                    if (ushort.TryParse(strValue, out ushort result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (ushort)mathResult;
+                    }
+                }
+
                 else if (valueType == typeof(int))
                 {
                     int tmpValue = 0;
@@ -56,8 +98,28 @@ namespace Frosty.Core.Controls.Editors
                     }
                     return tmpValue;
                 }
-                else if (valueType == typeof(long)) return long.Parse(strValue);
-                else if (valueType == typeof(ulong)) return ulong.Parse(strValue);
+                else if (valueType == typeof(long))
+                {
+                    if (long.TryParse(strValue, out long result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (long)mathResult;
+                    }
+                }
+                else if (valueType == typeof(ulong))
+                {
+                    if (ulong.TryParse(strValue, out ulong result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (ulong)mathResult;
+                    }
+                }
 
                 else if (valueType == typeof(float))
                 {
@@ -119,10 +181,52 @@ namespace Frosty.Core.Controls.Editors
                     if (strValue == "" || strValue == null)
                         return new ValidationResult(true, null);
 
-                    if (type == typeof(sbyte)) sbyte.Parse(strValue);
-                    else if (type == typeof(byte)) byte.Parse(strValue);
-                    else if (type == typeof(short)) short.Parse(strValue);
-                    else if (type == typeof(ushort)) ushort.Parse(strValue);
+                    if (type == typeof(sbyte))
+                    {
+                        if (sbyte.TryParse(strValue, out sbyte _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+                    else if (type == typeof(byte))
+                    {
+                        if (byte.TryParse(strValue, out byte _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+
+                    else if (type == typeof(short))
+                    {
+                        if (short.TryParse(strValue, out short _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+                    else if (type == typeof(ushort))
+                    {
+                        if (ushort.TryParse(strValue, out ushort _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+
                     else if (type == typeof(int))
                     {
                         if (int.TryParse(strValue, out int _) || TrySolve(strValue, out double _))
@@ -145,8 +249,29 @@ namespace Frosty.Core.Controls.Editors
                             return new ValidationResult(false, null);
                         }
                     }
-                    else if (type == typeof(long)) long.Parse(strValue);
-                    else if (type == typeof(ulong)) ulong.Parse(strValue);
+
+                    else if (type == typeof(long))
+                    {
+                        if (long.TryParse(strValue, out long _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+                    else if (type == typeof(ulong))
+                    {
+                        if (ulong.TryParse(strValue, out ulong _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
 
                     else if (type == typeof(float)) 
                     {

--- a/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
+++ b/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
@@ -125,37 +125,25 @@ namespace Frosty.Core.Controls.Editors
                     else if (type == typeof(ushort)) ushort.Parse(strValue);
                     else if (type == typeof(int))
                     {
-                        try
+                        if (int.TryParse(strValue, out int _) || TrySolve(strValue, out double _))
                         {
-                            if (int.TryParse(strValue, out int _) || TrySolve(strValue, out double _))
-                            {
-                                return new ValidationResult(true, null);
-                            }
-                            else
-                            {
-                                return new ValidationResult(false, null);
-                            }
+                            return new ValidationResult(true, null);
                         }
-                        catch (OverflowException) { return new ValidationResult(false, null); }
-                        catch (Exception) { }
-                        return new ValidationResult(true, null);
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
                     }
                     else if (type == typeof(uint))
                     {
-                        try
+                        if (uint.TryParse(strValue, out uint _) || TrySolve(strValue, out double _))
                         {
-                            if (uint.TryParse(strValue, out uint _) || TrySolve(strValue, out double _))
-                            {
-                                return new ValidationResult(true, null);
-                            }
-                            else
-                            {
-                                return new ValidationResult(false, null);
-                            }
+                            return new ValidationResult(true, null);
                         }
-                        catch (OverflowException) { return new ValidationResult(false, null); }
-                        catch (Exception) { }
-                        return new ValidationResult(true, null);
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
                     }
                     else if (type == typeof(long)) long.Parse(strValue);
                     else if (type == typeof(ulong)) ulong.Parse(strValue);

--- a/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
+++ b/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Frosty.Controls;
 using Frosty.Hash;
 using System;
+using System.Data;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
@@ -57,8 +58,29 @@ namespace Frosty.Core.Controls.Editors
                 }
                 else if (valueType == typeof(long)) return long.Parse(strValue);
                 else if (valueType == typeof(ulong)) return ulong.Parse(strValue);
-                else if (valueType == typeof(float)) return float.Parse(strValue);
-                else if (valueType == typeof(double)) return double.Parse(strValue);
+
+                else if (valueType == typeof(float))
+                {
+                    if (float.TryParse(strValue, out float result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return (float)mathResult;
+                    }
+                }
+                else if (valueType == typeof(double))
+                {
+                    if (double.TryParse(strValue, out double result))
+                    {
+                        return result;
+                    }
+                    else if (TrySolve(strValue, out double mathResult))
+                    {
+                        return mathResult;
+                    }
+                }
 
                 return 0;
             }
@@ -113,8 +135,29 @@ namespace Frosty.Core.Controls.Editors
                     }
                     else if (type == typeof(long)) long.Parse(strValue);
                     else if (type == typeof(ulong)) ulong.Parse(strValue);
-                    else if (type == typeof(float)) float.Parse(strValue);
-                    else if (type == typeof(double)) double.Parse(strValue);
+
+                    else if (type == typeof(float)) 
+                    {
+                        if (float.TryParse(strValue, out float _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
+                    else if (type == typeof(double))
+                    {
+                        if (double.TryParse(strValue, out double _) || TrySolve(strValue, out double _))
+                        {
+                            return new ValidationResult(true, null);
+                        }
+                        else
+                        {
+                            return new ValidationResult(false, null);
+                        }
+                    }
                 }
                 catch (Exception)
                 {
@@ -141,6 +184,21 @@ namespace Frosty.Core.Controls.Editors
             editor.VerticalContentAlignment = VerticalAlignment.Center;
             editor.Margin = new Thickness(-2, 0, 0, 0);
             editor.GotKeyboardFocus += (s, o) => { editor.SelectAll(); };
+            editor.AcceptsReturn = false;
+        }
+
+        private static bool TrySolve(string expression, out double result)
+        {
+            try
+            {
+                result = Convert.ToDouble(new DataTable().Compute(expression, null));
+                return true;
+            }
+            catch
+            {
+                result = double.NaN;
+                return false;
+            }
         }
     }
 }

--- a/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
+++ b/FrostyPlugin/Controls/Editors/FrostyNumberEditor.cs
@@ -92,6 +92,10 @@ namespace Frosty.Core.Controls.Editors
                     value = value.Remove(0, 2);
                     return int.Parse(value, NumberStyles.HexNumber);
                 }
+                else if (TrySolve(value, out double mathResult))
+                {
+                    return (int)mathResult;
+                }
                 else
                 {
                     value = value.Trim('\"');
@@ -121,14 +125,34 @@ namespace Frosty.Core.Controls.Editors
                     else if (type == typeof(ushort)) ushort.Parse(strValue);
                     else if (type == typeof(int))
                     {
-                        try { int.Parse(strValue); }
+                        try
+                        {
+                            if (int.TryParse(strValue, out int _) || TrySolve(strValue, out double _))
+                            {
+                                return new ValidationResult(true, null);
+                            }
+                            else
+                            {
+                                return new ValidationResult(false, null);
+                            }
+                        }
                         catch (OverflowException) { return new ValidationResult(false, null); }
                         catch (Exception) { }
                         return new ValidationResult(true, null);
                     }
                     else if (type == typeof(uint))
                     {
-                        try { uint.Parse(strValue); }
+                        try
+                        {
+                            if (uint.TryParse(strValue, out uint _) || TrySolve(strValue, out double _))
+                            {
+                                return new ValidationResult(true, null);
+                            }
+                            else
+                            {
+                                return new ValidationResult(false, null);
+                            }
+                        }
                         catch (OverflowException) { return new ValidationResult(false, null); }
                         catch (Exception) { }
                         return new ValidationResult(true, null);

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1363,16 +1363,19 @@ namespace Frosty.Core.Controls
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if (e.Key == Key.Subtract || e.Key == Key.Add)
+            if (e.Key == Key.Subtract || e.Key == Key.Add || e.Key == Key.Multiply)
             {
-                // to stop +/- from expanding/collapsing
+                // to stop +/-/* from expanding/collapsing
                 e.Handled = true;
 
                 if (e.OriginalSource is TextBox tb)
                 {
-                    // to ensure that textboxes still respond to +/-
+                    // to ensure that textboxes still respond to +/-/*
                     int lastLocation = tb.SelectionStart;
-                    tb.Text = tb.Text.Insert(lastLocation, (e.Key == Key.Subtract) ? "-" : "+");
+                    tb.Text = tb.Text.Insert(lastLocation, 
+                        (e.Key == Key.Subtract) ? "-" :
+                        (e.Key == Key.Add) ? "+" :
+                        (e.Key == Key.Multiply) ? "*" : "");
                     tb.SelectionStart = lastLocation + 1;
                 }
             }


### PR DESCRIPTION
Allow typing math expressions in float/double textboxes. Feature that I'm personally a fan of since I use it in Blender but I'm unsure if it would fit in Frosty.
![2023-08-17_21-18-10](https://github.com/CadeEvs/FrostyToolsuite/assets/13797470/8b7aa20e-f676-4daf-a364-aeb5e35bb309)
