### PR TITLE
Fix subworld and some texture duping

### DIFF
--- a/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
+++ b/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
@@ -111,7 +111,7 @@ namespace DuplicationPlugin
 
                 // Add new bundle
                 BundleEntry oldBundle = App.AssetManager.GetBundleEntry(newEntry.AddedBundles[0]);
-                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + newName, BundleType.SubLevel, oldBundle.SuperBundleId);
+                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + newName.ToLower(), BundleType.SubLevel, oldBundle.SuperBundleId);
 
                 newEntry.AddedBundles.Clear();
                 newEntry.AddedBundles.Add(App.AssetManager.GetBundleId(newBundle));

--- a/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
+++ b/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
@@ -489,19 +489,12 @@ namespace DuplicationPlugin
                 ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(texture.ChunkId);
 
                 // Duplicate the chunk
-                Guid chunkGuid = App.AssetManager.AddChunk(new NativeReader(texture.Data).ReadToEnd(), null, texture);
-                ChunkAssetEntry newChunkEntry = App.AssetManager.GetChunkEntry(chunkGuid);
+                ChunkAssetEntry newChunkEntry = DuplicateChunk(chunkEntry);
 
                 // Duplicate the res
-                ResAssetEntry newResEntry = App.AssetManager.AddRes(newName, ResourceType.Texture, resEntry.ResMeta, new NativeReader(App.AssetManager.GetRes(resEntry)).ReadToEnd());
+                ResAssetEntry newResEntry = DuplicateRes(resEntry, newName.ToLower(), ResourceType.Texture);
                 ((dynamic)newAsset.RootObject).Resource = newResEntry.ResRid;
                 Texture newTexture = App.AssetManager.GetResAs<Texture>(newResEntry);
-                newTexture.ChunkId = chunkGuid;
-                newTexture.AssetNameHash = (uint)Utils.HashString(newResEntry.Name, true);
-
-                // Add the new chunk/res entries to the original bundles
-                newResEntry.AddedBundles.AddRange(resEntry.EnumerateBundles());
-                newChunkEntry.AddedBundles.AddRange(chunkEntry.EnumerateBundles());
 
                 // Link the newly duplicates ebx, chunk, and res entries together
                 newResEntry.LinkAsset(newChunkEntry);

--- a/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
+++ b/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
@@ -492,9 +492,11 @@ namespace DuplicationPlugin
                 ChunkAssetEntry newChunkEntry = DuplicateChunk(chunkEntry);
 
                 // Duplicate the res
-                ResAssetEntry newResEntry = DuplicateRes(resEntry, newName.ToLower(), ResourceType.Texture);
+                ResAssetEntry newResEntry = DuplicateRes(resEntry, newName, ResourceType.Texture);
                 ((dynamic)newAsset.RootObject).Resource = newResEntry.ResRid;
                 Texture newTexture = App.AssetManager.GetResAs<Texture>(newResEntry);
+                newTexture.ChunkId = newChunkEntry.Id;
+                newTexture.AssetNameHash = (uint)Utils.HashString(newResEntry.Name, true);
 
                 // Link the newly duplicates ebx, chunk, and res entries together
                 newResEntry.LinkAsset(newChunkEntry);


### PR DESCRIPTION
This fixes an issue where duplicated subworlds have broken cases
(also fixes duping some texture types such as GradingLutAssets)