### PR TITLE
[LocalizedStringPlugin] Fix bug: "Export String Usage List" garbled

### DIFF
--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -8,6 +8,7 @@ using FrostySdk.IO;
 using FrostySdk.Managers;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -599,7 +600,7 @@ namespace LocalizedStringPlugin
                         }
                     }
 
-                    using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create), false, true))
+                    using (StreamWriter writer = new StreamWriter(sfd.FileName))
                     {
                         foreach (string StringData in StringInfo.Values)
                         {

--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -8,7 +8,6 @@ using FrostySdk.IO;
 using FrostySdk.Managers;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Plugins/LocalizedStringPlugin/Properties/AssemblyInfo.cs
+++ b/Plugins/LocalizedStringPlugin/Properties/AssemblyInfo.cs
@@ -23,6 +23,6 @@ using System.Windows;
 
 [assembly: PluginDisplayName("Localized String Editor")]
 [assembly: PluginAuthor("Mophead")]
-[assembly: PluginVersion("1.0.2.2")]
+[assembly: PluginVersion("1.0.2.3")]
 
 [assembly: RegisterMenuExtension(typeof(LocalizedStringViewerMenuExtension))]


### PR DESCRIPTION
Because `FrostySdk.IO.NativeWriter` is based on `BinaryWriter`, many characters cannot be stored normally (in binary)  
I changed it to `System.IO.StreamWriter` and tested successfully on GW2 with zhTC  
The following is the multilingual detailed test results  

<details><summary>FrostySdk.IO.NativeWriter</summary>
<p>
Code:

```c#
using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create), false, true))
{
    writer.WriteLine("FrostySdk.IO.NativeWriter(Old)\n\nEnglish__Frosty Toolsuite\nFrench__Suite d'outils givrés\nPolish__Mroźny zestaw narzędzi\nArabic__مجموعة الأدوات الفاترة\nJapanese__フロスティツールスイート\nKorean__프로스티 툴스위트\nzhTC__Frosty 工具套件(繁體)\nzhCN__Frosty 工具套件(简体)\nRussian__Набор инструментов Frosty");
}
``` 
Result:

```
F r o s t y S d k . I O . N a t i v e W r i t e r ( O l d ) 

 E n g l i s h _ _ F r o s t y   T o o l s u i t e 
 F r e n c h _ _ S u i t e   d ' o u t i l s   g i v r ? s 
 P o l i s h _ _ M r o zn y   z e s t a w   n a r z d z i 
 A r a b i c _ _ E,EH9)  'D#/H'*  'DA'*1)
 J a p a n e s e _ _ ????????????
 K o r e a n _ _ 誠袱吗? 4窑?歉? z h T C _ _ F r o s t y   錧wQWY鯪( A~詺) 
 z h C N _ _ F r o s t y   錧wQWY鯪( €{SO) 
 R u s s i a n _ _ 01>@  8=AB@C<5=B>2  F r o s t y 
 
 
``` 
</p>
</details> 

<details><summary>System.IO.StreamWriter</summary>
<p>
Code:

```c#
using (StreamWriter writer = new StreamWriter(sfd.FileName + "new"))
{
    writer.WriteLine("System.IO.StreamWriter(New)\n\nEnglish__Frosty Toolsuite\nFrench__Suite d'outils givrés\nPolish__Mroźny zestaw narzędzi\nArabic__مجموعة الأدوات الفاترة\nJapanese__フロスティツールスイート\nKorean__프로스티 툴스위트\nzhTC__Frosty 工具套件(繁體)\nzhCN__Frosty 工具套件(简体)\nRussian__Набор инструментов Frosty");
}
``` 
Result:

```
System.IO.StreamWriter(New)

English__Frosty Toolsuite
French__Suite d'outils givrés
Polish__Mroźny zestaw narzędzi
Arabic__مجموعة الأدوات الفاترة
Japanese__フロスティツールスイート
Korean__프로스티 툴스위트
zhTC__Frosty 工具套件(繁體)
zhCN__Frosty 工具套件(简体)
Russian__Набор инструментов Frosty

``` 