### PR TITLE
[LocalizedStringPlugin] Fix bugs that were not fixed last time

### DIFF
--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -8,6 +8,7 @@ using FrostySdk.IO;
 using FrostySdk.Managers;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -599,7 +600,7 @@ namespace LocalizedStringPlugin
                         }
                     }
 
-                    using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create), false, true))
+                    using (StreamWriter writer = new StreamWriter(sfd.FileName))
                     {
                         foreach (string StringData in StringInfo.Values)
                         {

--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -8,7 +8,6 @@ using FrostySdk.IO;
 using FrostySdk.Managers;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
+++ b/Plugins/LocalizedStringPlugin/FrostyLocalizedStringViewer.cs
@@ -482,7 +482,7 @@ namespace LocalizedStringPlugin
             {
                 FrostyTaskWindow.Show("Exporting Localized Strings", "", (task) =>
                 {
-                    using (NativeWriter writer = new NativeWriter(new FileStream(sfd.FileName, FileMode.Create), false, true))
+                    using (StreamWriter writer = new StreamWriter(sfd.FileName))
                     {
                         int index = 0;
                         foreach (uint stringId in stringIds)
@@ -512,11 +512,11 @@ namespace LocalizedStringPlugin
                 int added = 0;
                 FrostyTaskWindow.Show("Importing Localized Strings", "", (task) =>
                 {
-                    using (NativeReader reader = new NativeReader(new FileStream(ofd.FileName, FileMode.Open)))
+                    using (StreamReader reader = new StreamReader(ofd.FileName))
                     {
-                        while (reader.Position < reader.Length)
+                        while (!reader.EndOfStream)
                         {
-                            string line = reader.ReadWideLine();
+                            string line = reader.ReadLine();
                             uint hash = uint.Parse(line.Substring(0, 8), System.Globalization.NumberStyles.HexNumber);
                             string s = line.Substring(10, line.Length - 11);
                             if (stringIds.Contains(hash) && s != db.GetString(hash))

--- a/Plugins/LocalizedStringPlugin/Properties/AssemblyInfo.cs
+++ b/Plugins/LocalizedStringPlugin/Properties/AssemblyInfo.cs
@@ -23,6 +23,6 @@ using System.Windows;
 
 [assembly: PluginDisplayName("Localized String Editor")]
 [assembly: PluginAuthor("Mophead")]
-[assembly: PluginVersion("1.0.2.2")]
+[assembly: PluginVersion("1.0.2.3")]
 
 [assembly: RegisterMenuExtension(typeof(LocalizedStringViewerMenuExtension))]


### PR DESCRIPTION
#297 is not finished, I only fixed "Export String Usage List". Sorry
Now I also fixed "Export String List" and "Import String List"
I have successfully tested in GW2 using
<details><summary>test content in #297 </summary>
<p>

```
English__Frosty Toolsuite
French__Suite d'outils givrés
Polish__Mroźny zestaw narzędzi
Arabic__مجموعة الأدوات الفاترة
Japanese__フロスティツールスイート
Korean__프로스티 툴스위트
zhTC__Frosty 工具套件(繁體)
zhCN__Frosty 工具套件(简体)
Russian__Набор инструментов Frosty

```
</p>
</details> 