### PR TITLE
Added a "ModifiesAddedAssets" variable to IModCustomHandler

### DIFF
--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -301,9 +301,12 @@ namespace Frosty.ModSupport
 
                                 // add in existing bundles
                                 var ebxEntry = am.GetEbxEntry(resource.Name);
-                                foreach (int bid in ebxEntry.Bundles)
+                                if (ebxEntry != null)
                                 {
-                                    bundles.Add(HashBundle(am.GetBundleEntry(bid)));
+                                    foreach (int bid in ebxEntry.Bundles)
+                                    {
+                                        bundles.Add(HashBundle(am.GetBundleEntry(bid)));
+                                    }
                                 }
 
                                 entry.ExtraData = extraData;

--- a/FrostyPlugin/Handlers/LegacyCustomActionHandler.cs
+++ b/FrostyPlugin/Handlers/LegacyCustomActionHandler.cs
@@ -15,6 +15,8 @@ namespace Frosty.Core.Handlers
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class ModLegacyFileEntry
         {
             public int Hash { get; set; }

--- a/FrostyPlugin/IO/FrostyModWriter.cs
+++ b/FrostyPlugin/IO/FrostyModWriter.cs
@@ -330,7 +330,7 @@ namespace Frosty.Core.IO
                     if (entry.HasModifiedData)
                     {
                         ICustomActionHandler actionHandler = App.PluginManager.GetCustomHandler(entry.Type);
-                        if (actionHandler != null && !entry.IsAdded)
+                        if (actionHandler != null && (!entry.IsAdded || actionHandler.ModifiesAddedAssets == true))
                         {
                             // use custom action handler to save asset to mod
                             actionHandler.SaveToMod(this, entry);

--- a/FrostyPlugin/Mod/IModCustomHandler.cs
+++ b/FrostyPlugin/Mod/IModCustomHandler.cs
@@ -16,6 +16,11 @@ namespace Frosty.Core.Mod
         HandlerUsage Usage { get; }
 
         /// <summary>
+        /// Allows custom handlers to be used on duplicated assets which will make them mergable in FMM.
+        /// </summary>
+        bool ModifiesAddedAssets { get; }
+
+        /// <summary>
         /// Handles the loading and merging of the custom data.
         /// </summary>
         /// <param name="existing">The existing object data that has been loaded from previous mods.</param>

--- a/Plugins/BiowareLocalizationPlugin/BiowareLocalizationCustomActionHandler.cs
+++ b/Plugins/BiowareLocalizationPlugin/BiowareLocalizationCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace BiowareLocalizationPlugin
 
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/DifficultyWeaponTableDataPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
+++ b/Plugins/DifficultyWeaponTableDataPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
@@ -22,6 +22,8 @@ namespace DifficultyWeaponTableDataPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
+++ b/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace FsLocalizationPlugin
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class FsLocalizationResource : EditorModResource
         {
             public override ModResourceType Type => ModResourceType.Ebx;

--- a/Plugins/MeshSetPlugin/Handlers/ShaderBlockDepotCustomActionHandler.cs
+++ b/Plugins/MeshSetPlugin/Handlers/ShaderBlockDepotCustomActionHandler.cs
@@ -13,6 +13,8 @@ namespace MeshSetPlugin.Handlers
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class ShaderBlockDepotResource : EditorModResource
         {
             public static uint Hash => 0x89ef2205;

--- a/Plugins/TestPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
+++ b/Plugins/TestPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
@@ -18,6 +18,8 @@ namespace TestPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/TestPlugin/Handlers/SvgImageCustomActionHandler.cs
+++ b/Plugins/TestPlugin/Handlers/SvgImageCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace TestPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Modify;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This


### PR DESCRIPTION
Allows custom handlers to apply (and therefore merge) duplicated assets. The use case being in SWBF2 it is possible to create new subworlds which need mergable network registries in order for players synchronise correctly in MP servers. This functionality is completely disabled for all of the base Frosty plugins (besides the Gameplay Merger which I have specifically set it up for) so you don't need to worry about it breaking those plugins. Feel free to find a flaw in my code, this implementation is as simple as I could make it and I have tested it in both FMM and FE.