### PR TITLE
[Core/Editor] Improvements to .bin import/export

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -1012,7 +1012,7 @@ namespace FrostyEditor
                 if (assetDefinition.Import(entry, ofd.FileName, filters[ofd.FilterIndex - 1].Extension))
                 {
                     dataExplorer.RefreshItems();
-                    App.Logger.Log("Imported {0} to {1}", entry.Name, ofd.FileName);
+                    App.Logger.Log("Imported {0} into {1}", ofd.FileName, entry.Name);
                 }
             }
         }

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -1009,7 +1009,7 @@ namespace FrostyEditor
             FrostyOpenFileDialog ofd = new FrostyOpenFileDialog("Import Asset", filterString, assetDefinition.GetType().Name);
             if (ofd.ShowDialog())
             {
-                if (assetDefinition.Import(entry, ofd.FileName, filters[ofd.FilterIndex - 1].Extension))
+                if (assetDefinition.Import(entry, ofd.FileName, filters[ofd.FilterIndex - 1]))
                 {
                     dataExplorer.RefreshItems();
                     App.Logger.Log("Imported {0} into {1}", ofd.FileName, entry.Name);

--- a/FrostyPlugin/AssetDefinition.cs
+++ b/FrostyPlugin/AssetDefinition.cs
@@ -222,7 +222,7 @@ namespace Frosty.Core
         {
             if (App.PluginManager.GetCustomHandler(entry.Type) != null)
             {
-                App.Logger.LogError("Cannot Import asset with handler to .bin");
+                App.Logger.LogError("Cannot Import .bin into asset with handler");
                 return;
             }
 

--- a/FrostyPlugin/AssetDefinition.cs
+++ b/FrostyPlugin/AssetDefinition.cs
@@ -196,7 +196,7 @@ namespace Frosty.Core
         {
             if (App.PluginManager.GetCustomHandler(entry.Type) != null)
             {
-                // @todo: throw some kind of error
+                App.Logger.LogError("Cannot Export asset with handler to .bin");
                 return;
             }
 

--- a/FrostyPlugin/AssetDefinition.cs
+++ b/FrostyPlugin/AssetDefinition.cs
@@ -222,7 +222,7 @@ namespace Frosty.Core
         {
             if (App.PluginManager.GetCustomHandler(entry.Type) != null)
             {
-                App.Logger.LogError("Cannot Export asset with handler to .bin");
+                App.Logger.LogError("Cannot Import asset with handler to .bin");
                 return;
             }
 

--- a/FrostyPlugin/AssetDefinition.cs
+++ b/FrostyPlugin/AssetDefinition.cs
@@ -96,8 +96,8 @@ namespace Frosty.Core
         /// <param name="exportTypes">A list of <see cref="AssetExportType"/> to be populated.</param>
         public virtual void GetSupportedExportTypes(List<AssetExportType> exportTypes)
         {
-            exportTypes.Add(new AssetExportType("xml", "XML File"));
             exportTypes.Add(new AssetExportType("bin", "Binary File"));
+            exportTypes.Add(new AssetExportType("xml", "XML File"));
         }
 
         /// <summary>

--- a/FrostyPlugin/AssetDefinition.cs
+++ b/FrostyPlugin/AssetDefinition.cs
@@ -222,7 +222,7 @@ namespace Frosty.Core
         {
             if (App.PluginManager.GetCustomHandler(entry.Type) != null)
             {
-                // @todo: throw some kind of error
+                App.Logger.LogError("Cannot Export asset with handler to .bin");
                 return;
             }
 


### PR DESCRIPTION
- Export asset as .bin by default rather than .xml
- Fix order of import log to be more intuitive (redo of #50)
- Option to import only the data of the bin, leaving the original FileGuid and RootInstanceGuid intact
- LogError if exporting asset with handler