### PR TITLE
[Mod Manager] Allow the mod manager to load menu extensions from plugins

### DIFF
--- a/FrostyModManager/Windows/MainWindow.xaml
+++ b/FrostyModManager/Windows/MainWindow.xaml
@@ -265,7 +265,8 @@
             </Grid.RowDefinitions>
 
             <!-- Menu -->
-            <Menu Grid.Row="0">
+            <Menu x:Name="menu"
+                  Grid.Row="0">
                 <MenuItem Header="File"
                           Height="22">
                     <MenuItem Header="Pack">

--- a/FrostyPlugin/Attributes/RegisterMenuExtensionAttribute.cs
+++ b/FrostyPlugin/Attributes/RegisterMenuExtensionAttribute.cs
@@ -23,7 +23,13 @@ namespace Frosty.Core.Attributes
         /// Initializes a new instance of the <see cref="RegisterMenuExtensionAttribute"/> class using the menu extension type.
         /// </summary>
         /// <param name="type">The type of the menu extension. This type must derive from <see cref="MenuExtension"/></param>
-        public RegisterMenuExtensionAttribute(Type type, PluginManagerType managerType = PluginManagerType.Editor)
+        public RegisterMenuExtensionAttribute(Type type)
+        {
+            MenuExtensionType = type;
+            ManagerType = PluginManagerType.Editor;
+        }
+
+        public RegisterMenuExtensionAttribute(Type type, PluginManagerType managerType)
         {
             MenuExtensionType = type;
             ManagerType = managerType;

--- a/FrostyPlugin/Attributes/RegisterMenuExtensionAttribute.cs
+++ b/FrostyPlugin/Attributes/RegisterMenuExtensionAttribute.cs
@@ -15,12 +15,18 @@ namespace Frosty.Core.Attributes
         public Type MenuExtensionType { get; private set; }
 
         /// <summary>
+        /// Gets the manager type to define if the options extension should be loaded for the Mod Manager or Editor.
+        /// </summary>
+        public PluginManagerType ManagerType { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RegisterMenuExtensionAttribute"/> class using the menu extension type.
         /// </summary>
         /// <param name="type">The type of the menu extension. This type must derive from <see cref="MenuExtension"/></param>
-        public RegisterMenuExtensionAttribute(Type type)
+        public RegisterMenuExtensionAttribute(Type type, PluginManagerType managerType = PluginManagerType.Editor)
         {
             MenuExtensionType = type;
+            ManagerType = managerType;
         }
     }
 }

--- a/FrostyPlugin/PluginManager.cs
+++ b/FrostyPlugin/PluginManager.cs
@@ -425,7 +425,7 @@ namespace Frosty.Core
 
             foreach (var tmpAttr in assembly.GetCustomAttributes())
             {
-                if (m_managerType == PluginManagerType.ModManager && !(tmpAttr is RegisterCustomHandlerAttribute) && !(tmpAttr is RegisterExecutionAction) && !(tmpAttr is RegisterOptionsExtensionAttribute))
+                if (m_managerType == PluginManagerType.ModManager && !(tmpAttr is RegisterCustomHandlerAttribute) && !(tmpAttr is RegisterExecutionAction) && !(tmpAttr is RegisterOptionsExtensionAttribute) && !(tmpAttr is RegisterMenuExtensionAttribute))
                     continue;
 
                 if (loadType == PluginLoadType.Startup)
@@ -484,9 +484,12 @@ namespace Frosty.Core
                     }
                     else if (tmpAttr is RegisterMenuExtensionAttribute attr2)
                     {
-                        if (!attr2.MenuExtensionType.IsSubclassOf(typeof(MenuExtension)))
-                            throw new Exception("Menu extensions must extend from MenuExtensions base class");
-                        m_menuExtensions.Add((MenuExtension)Activator.CreateInstance(attr2.MenuExtensionType));
+                        if (attr2.ManagerType == m_managerType || attr2.ManagerType == PluginManagerType.Both)
+                        {
+                            if (!attr2.MenuExtensionType.IsSubclassOf(typeof(MenuExtension)))
+                                throw new Exception("Menu extensions must extend from MenuExtensions base class");
+                            m_menuExtensions.Add((MenuExtension)Activator.CreateInstance(attr2.MenuExtensionType));
+                        }
                     }
                     else if (tmpAttr is RegisterOptionsExtensionAttribute attr5)
                     {


### PR DESCRIPTION
All the code is straight from the editor or from other menu extensions, meaning it should work perfectly