### PR TITLE
[ModSupport] Check for filename in modinfo equality

### DIFF
--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -157,7 +157,7 @@ namespace Frosty.ModSupport
 
             public bool Equals(ModInfo other)
             {
-                return Name == other.Name && Version == other.Version && Category == other.Category;
+                return Name == other.Name && Version == other.Version && Category == other.Category && FileName == other.FileName;
             }
 
             public override int GetHashCode()


### PR DESCRIPTION
Not 100% sure why it doesn't already, I mustve forgot in my initial PR for it