### PR TITLE
Check if mesh has chunks before bundle editing

### DIFF
--- a/Plugins/BundleEditorPlugin/BundleEditor.cs
+++ b/Plugins/BundleEditorPlugin/BundleEditor.cs
@@ -81,9 +81,12 @@ namespace BundleEditPlugin
             {
                 foreach (MeshSetLod lod in meshSetRes.Lods)
                 {
-                    ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
-                    chunkEntry.AddedBundles.Remove(App.AssetManager.GetBundleId(bentry));
-                    resEntry.LinkAsset(chunkEntry);
+                    if (lod.ChunkId != Guid.Empty)
+                    {
+                        ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
+                        chunkEntry.AddedBundles.Remove(App.AssetManager.GetBundleId(bentry));
+                        resEntry.LinkAsset(chunkEntry);
+                    }
                 }
             }
 
@@ -260,9 +263,12 @@ namespace BundleEditPlugin
             {
                 foreach (MeshSetLod lod in meshSetRes.Lods)
                 {
-                    ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
-                    chunkEntry.AddToBundle(App.AssetManager.GetBundleId(bentry));
-                    resEntry.LinkAsset(chunkEntry);
+                    if (lod.ChunkId != Guid.Empty)
+                    {
+                        ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
+                        chunkEntry.AddToBundle(App.AssetManager.GetBundleId(bentry));
+                        resEntry.LinkAsset(chunkEntry);
+                    }
                 }
             }
 


### PR DESCRIPTION
This checks to see if the LOD's chunk is not empty before bundle editing. To prevent crashes if lod data is stored in the mesh instead of chunks