### PR TITLE
Make it Task an optional param for LoadVariations

### DIFF
--- a/FrostyPlugin/Viewport/MeshVariationDb.cs
+++ b/FrostyPlugin/Viewport/MeshVariationDb.cs
@@ -123,7 +123,7 @@ namespace Frosty.Core.Viewport
 
         private static Dictionary<Guid, MeshVariationDbEntry> modifiedentries = new Dictionary<Guid, MeshVariationDbEntry>();
 
-        public static void LoadVariations(FrostyTaskWindow task)
+        public static void LoadVariations(FrostyTaskWindow task = null)
         {
             int mvdbVersion = 1;
 
@@ -139,7 +139,7 @@ namespace Frosty.Core.Viewport
             uint index = 0;
 
             entries.Clear();
-            task.Update("Loading Variation Databases");
+            task?.Update("Loading Variation Databases");
 
             string cache = System.AppDomain.CurrentDomain.BaseDirectory + @"\Caches\" + Enum.GetName(typeof(ProfileVersion), ProfilesLibrary.DataVersion) + "_mvdb.cache";
             bool generateMVDB = true;
@@ -206,7 +206,7 @@ namespace Frosty.Core.Viewport
                 foreach (EbxAssetEntry ebx in App.AssetManager.EnumerateEbx("MeshVariationDatabase"))
                 {
                     uint progress = (uint)((index / (float)totalCount) * 100);
-                    task.Update(progress: progress);
+                    task?.Update(progress: progress);
                     if (ebx.IsAdded)
                         continue;
                     EbxAsset asset = App.AssetManager.GetEbx(ebx, true);


### PR DESCRIPTION
This makes the FrostyTaskWindow optional for LoadVariations, that way you don't need to call FrostyTaskWindow.Show() every time you call MeshVariationDb.LoadVariations