### PR TITLE
[LevelEditor] Extreme optimizations loading LevelData

### DIFF
--- a/Editors/LevelEditor.cs
+++ b/Editors/LevelEditor.cs
@@ -249,7 +249,9 @@ namespace LevelEditorPlugin.Editors
                 viewport.SetPaused(false);
 
                 editingWorld = refObj;
-                currentLoadingState = null;
+                //currentLoadingState = null;
+
+                currentLoadingState.Task.Update("Initializing EntityWorld");
 
                 world.Initialize();
             });


### PR DESCRIPTION
optimized loading it through Dictionaries and not using FirstOrDefault() 
on a *180,000* long list of entities time goes from like 25 minutes to 1 minute on average 
for deathstar2_01, it went from *42:55* to 1:15