### PR TITLE
Clipboard Try Catch

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -1589,11 +1589,18 @@ namespace FrostyEditor
             Plugin selectedPlugin = (Plugin)LoadedPluginsList.SelectedItem;
 
             // retrieve the selected plugin's load exception, execute ToString on it, and add the result to the clipboard
-            Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+            try
             {
-                DateTime.Now.ToString(),
-                selectedPlugin.LoadException.ToString()
-            }));
+                Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+                {
+                    DateTime.Now.ToString(),
+                    selectedPlugin.LoadException.ToString()
+                }));
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
     }
 }

--- a/FrostyModManager/Windows/MainWindow.xaml.cs
+++ b/FrostyModManager/Windows/MainWindow.xaml.cs
@@ -2023,11 +2023,18 @@ namespace FrostyModManager
             Plugin selectedPlugin = (Plugin)LoadedPluginsList.SelectedItem;
 
             // retrieve the selected plugin's load exception, execute ToString on it, and add the result to the clipboard
-            Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+            try
             {
-                DateTime.Now.ToString(),
-                selectedPlugin.LoadException.ToString()
-            }));
+                Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+                {
+                    DateTime.Now.ToString(),
+                    selectedPlugin.LoadException.ToString()
+                }));
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         private void LoadMenuExtensions()

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1266,8 +1266,14 @@ namespace Frosty.Core.Controls
                 dynamic obj = pointerRef.Internal;
                 guidToCopy = obj.GetInstanceGuid().ToString();
             }
-
-            Clipboard.SetText(guidToCopy);
+            try
+            {
+                Clipboard.SetText(guidToCopy);
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         /// <summary>

--- a/Plugins/BiowareLocalizationPlugin/Controls/ListBoxUtils.cs
+++ b/Plugins/BiowareLocalizationPlugin/Controls/ListBoxUtils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Frosty.Core;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -49,7 +50,14 @@ namespace BiowareLocalizationPlugin.Controls
                     sb.AppendLine(selected.ToString());
                 }
 
-                Clipboard.SetText(sb.ToString());
+                try
+                {
+                    Clipboard.SetText(sb.ToString());
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
             }
         }
     }

--- a/Plugins/DelayLoadBundlePlugin/DAIDelayLoadBundleEditor.cs
+++ b/Plugins/DelayLoadBundlePlugin/DAIDelayLoadBundleEditor.cs
@@ -81,7 +81,14 @@ namespace DelayLoadBundlePlugin
             if (selectedItem == null)
                 return;
 
-            Clipboard.SetText(selectedItem.Hash.ToString());
+            try
+            {
+                Clipboard.SetText(selectedItem.Hash.ToString());
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         GridViewColumnHeader lastSortHeader;

--- a/Plugins/LuaPlugin/CodeEditor/CodeEditor.cs
+++ b/Plugins/LuaPlugin/CodeEditor/CodeEditor.cs
@@ -400,6 +400,15 @@ namespace LuaPlugin.CodeEditor
                 // Cut selection
                 int imin = SelectionStart.Index <= SelectionEnd.Index ? SelectionStart.Index : SelectionEnd.Index;
                 int imax = SelectionStart.Index <= SelectionEnd.Index ? SelectionEnd.Index : SelectionStart.Index;
+
+                try
+                {
+                    Clipboard.SetText(Text.Substring(imin, imax - imin));
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
                 Clipboard.SetText(Text.Substring(imin, imax - imin));
                 ModifyText(imin, imax, "");
                 CaretBlink = true;
@@ -412,7 +421,15 @@ namespace LuaPlugin.CodeEditor
                 // Copy selection
                 int imin = SelectionStart.Index <= SelectionEnd.Index ? SelectionStart.Index : SelectionEnd.Index;
                 int imax = SelectionStart.Index <= SelectionEnd.Index ? SelectionEnd.Index : SelectionStart.Index;
-                Clipboard.SetText(Text.Substring(imin, imax - imin));
+
+                try
+                {
+                    Clipboard.SetText(Text.Substring(imin, imax - imin));
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
                 CaretBlink = true;
                 InvalidateVisual();
             }


### PR DESCRIPTION
A wise man once said "Every time Frosty copies to the clipboard the gods toss a coin in the air and the modder holds his breath to see how it will land". This PR prevents one of the most frequent and insufferable crashes by adding a try catch to every single Clipboard.SetText() in Frosty. I have no idea why copying to the clipboard crashes so much in the first place but unless an alternate way can be found which works 100% of the time then this try catch will have to do for now.