### PR TITLE
Added the ability to paste shallow copies and pointer refs.

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -1589,11 +1589,18 @@ namespace FrostyEditor
             Plugin selectedPlugin = (Plugin)LoadedPluginsList.SelectedItem;
 
             // retrieve the selected plugin's load exception, execute ToString on it, and add the result to the clipboard
-            Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+            try
             {
-                DateTime.Now.ToString(),
-                selectedPlugin.LoadException.ToString()
-            }));
+                Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+                {
+                    DateTime.Now.ToString(),
+                    selectedPlugin.LoadException.ToString()
+                }));
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
     }
 }

--- a/FrostyModManager/Windows/MainWindow.xaml.cs
+++ b/FrostyModManager/Windows/MainWindow.xaml.cs
@@ -2023,11 +2023,18 @@ namespace FrostyModManager
             Plugin selectedPlugin = (Plugin)LoadedPluginsList.SelectedItem;
 
             // retrieve the selected plugin's load exception, execute ToString on it, and add the result to the clipboard
-            Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+            try
             {
-                DateTime.Now.ToString(),
-                selectedPlugin.LoadException.ToString()
-            }));
+                Clipboard.SetText(string.Format("[{0}]\n{1}", new string[]
+                {
+                    DateTime.Now.ToString(),
+                    selectedPlugin.LoadException.ToString()
+                }));
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         private void LoadMenuExtensions()

--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -283,7 +283,7 @@ namespace Frosty.ModSupport
                             HandlerExtraData extraData;
                             byte[] data = fmod.GetResourceData(resource);
 
-                            if (modifiedEbx.TryGetValue(resource.Name, out EbxAssetEntry entry))
+                            if (modifiedEbx.TryGetValue(resource.Name, out EbxAssetEntry entry) && entry.ExtraData != null)
                             {
                                 extraData = (HandlerExtraData)entry.ExtraData;
                             }
@@ -307,7 +307,10 @@ namespace Frosty.ModSupport
                                 }
 
                                 entry.ExtraData = extraData;
-                                modifiedEbx.TryAdd(resource.Name, entry);
+                                if (modifiedEbx.ContainsKey(resource.Name))
+                                    modifiedEbx[resource.Name] = entry;
+                                else
+                                    modifiedEbx.TryAdd(resource.Name, entry);
                             }
 
                             // merge new and old data together

--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -301,9 +301,12 @@ namespace Frosty.ModSupport
 
                                 // add in existing bundles
                                 var ebxEntry = am.GetEbxEntry(resource.Name);
-                                foreach (int bid in ebxEntry.Bundles)
+                                if (ebxEntry != null)
                                 {
-                                    bundles.Add(HashBundle(am.GetBundleEntry(bid)));
+                                    foreach (int bid in ebxEntry.Bundles)
+                                    {
+                                        bundles.Add(HashBundle(am.GetBundleEntry(bid)));
+                                    }
                                 }
 
                                 entry.ExtraData = extraData;

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1229,6 +1229,17 @@ namespace Frosty.Core.Controls
                 };
                 mi.Click += CopyGuidMenuItem_Click;
                 cm.Items.Add(mi);
+
+                mi = new MenuItem
+                {
+                    Header = "Filter Guid",
+                    Icon = new Image
+                    {
+                        Source = StringToBitmapSourceConverter.CopySource
+                    }
+                };
+                mi.Click += FilterByObjsGuidMenuItem_Click;
+                cm.Items.Add(mi);
             }
 
             if (item.IsArrayChild)
@@ -1268,6 +1279,31 @@ namespace Frosty.Core.Controls
             }
 
             Clipboard.SetText(guidToCopy);
+        }
+        
+        /// <summary>
+         /// Copies the PointerRef's guid to the filter bar
+         /// </summary>
+        private void FilterByObjsGuidMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            FrostyPropertyGridItemData item = (FrostyPropertyGridItemData)DataContext;
+
+            string guidToCopy = "";
+
+            PointerRef pointerRef = (PointerRef)item.Value;
+            if (pointerRef.Type == PointerRefType.Null)
+                guidToCopy = "";
+            else if (pointerRef.Type == PointerRefType.External)
+                guidToCopy = pointerRef.External.ClassGuid.ToString();
+            else
+            {
+                dynamic obj = pointerRef.Internal;
+                guidToCopy = obj.GetInstanceGuid().ToString();
+            }
+            FrostyPropertyGrid pg = GetPropertyGrid();
+            pg.filterBox.WatermarkText = "";
+            pg.filterBox.Text = "guid:" + guidToCopy;
+            pg.FilterTextInBox();
         }
 
         /// <summary>
@@ -1527,7 +1563,7 @@ namespace Frosty.Core.Controls
         private BaseTypeOverride additionalData;
 
         private TreeView tv;
-        private FrostyWatermarkTextBox filterBox;
+        public FrostyWatermarkTextBox filterBox;
         private Border filterInProgressBorder;
         private ProgressBar filterProgressBar;
         private ObservableCollection<FrostyPropertyGridItemData> items;
@@ -1587,6 +1623,11 @@ namespace Frosty.Core.Controls
         }
 
         private async void FilterBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            FilterTextInBox();
+        }
+
+        public async void FilterTextInBox()
         {            
             string filterText = filterBox.Text;
             if (filterText == FilterText)

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1266,8 +1266,14 @@ namespace Frosty.Core.Controls
                 dynamic obj = pointerRef.Internal;
                 guidToCopy = obj.GetInstanceGuid().ToString();
             }
-
-            Clipboard.SetText(guidToCopy);
+            try
+            {
+                Clipboard.SetText(guidToCopy);
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         /// <summary>

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -1229,6 +1229,31 @@ namespace Frosty.Core.Controls
                 };
                 mi.Click += CopyGuidMenuItem_Click;
                 cm.Items.Add(mi);
+
+                mi = new MenuItem
+                {
+                    Header = "Paste Shallow",
+                    Icon = new Image
+                    {
+                        Source = StringToBitmapSourceConverter.PasteSource
+                    }
+                };
+                mi.Click += PasteShallowMenuItem_Click;
+                BindingOperations.SetBinding(mi, IsEnabledProperty, new Binding("HasPointerRef") { Source = FrostyClipboard.Current });
+                cm.Items.Add(mi);
+
+
+                mi = new MenuItem
+                {
+                    Header = "Paste Reference",
+                    Icon = new Image
+                    {
+                        Source = StringToBitmapSourceConverter.PasteSource
+                    }
+                };
+                mi.Click += PastePrMenuItem_Click;
+                BindingOperations.SetBinding(mi, IsEnabledProperty, new Binding("HasPointerRef") { Source = FrostyClipboard.Current });
+                cm.Items.Add(mi);
             }
 
             if (item.IsArrayChild)
@@ -1308,6 +1333,64 @@ namespace Frosty.Core.Controls
             }
         }
 
+        /// <summary>
+        /// Tries to paste a shallow copy of clipboard data
+        /// </summary>
+        private void PasteShallowMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (FrostyClipboard.Current.HasData)
+            {
+                FrostyPropertyGridItemData item = (FrostyPropertyGridItemData)DataContext;
+                if (item.IsEnabled && !item.IsReadOnly)
+                {
+                    if (FrostyClipboard.Current.IsType(item.Value.GetType()))
+                    {
+                        FrostyPropertyGrid pg = GetPropertyGrid();
+
+                        if (pg.Asset != null)
+                        {
+                            // property grid is displaying an asset
+                            item.Value = FrostyClipboard.Current.GetData(pg.Asset, App.AssetManager.GetEbxEntry(pg.Asset.FileGuid), type: FrostyClipboard.PasteType.Shallow);
+                        }
+                        else
+                        {
+                            // property grid is displaying a custom EBX class
+                            item.Value = FrostyClipboard.Current.GetData();
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to paste a PR copy of clipboard data
+        /// </summary>
+        private void PastePrMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (FrostyClipboard.Current.HasData)
+            {
+                FrostyPropertyGridItemData item = (FrostyPropertyGridItemData)DataContext;
+                if (item.IsEnabled && !item.IsReadOnly)
+                {
+                    if (FrostyClipboard.Current.IsType(item.Value.GetType()))
+                    {
+                        FrostyPropertyGrid pg = GetPropertyGrid();
+
+                        if (pg.Asset != null)
+                        {
+                            // property grid is displaying an asset
+                            item.Value = FrostyClipboard.Current.GetData(pg.Asset, App.AssetManager.GetEbxEntry(pg.Asset.FileGuid), FrostyClipboard.PasteType.PR);
+                            //item.Value = FrostyClipboard.Current.Data;
+                        }
+                        else
+                        {
+                            // property grid is displaying a custom EBX class
+                            item.Value = FrostyClipboard.Current.GetData();
+                        }
+                    }
+                }
+            }
+        }
         private FrostyPropertyGrid GetPropertyGrid()
         {
             DependencyObject parent = VisualTreeHelper.GetParent(this);

--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -713,6 +713,61 @@ namespace Frosty.Core.Controls
             return retVal;
         }
 
+        public bool FilterAsset(string asset, List<object> refObjects, bool doNotHideSubObjects = false)
+        {
+            if (_value is PointerRef pRef)
+            {
+                if (pRef.Type == PointerRefType.Internal)
+                {
+                    if (GetCustomAttribute<IsReferenceAttribute>() == null)
+                    {
+                        if (refObjects.Contains(pRef.Internal))
+                            return true;
+                        refObjects.Add(pRef.Internal);
+                    }
+                }
+            }
+
+            bool retVal = true;
+
+            foreach (var item in Children)
+            {
+                if (new List<string>() { "PropertyConnection", "EventConnection", "LinkConnection" }.Contains(item.Value.GetType().Name))
+                {
+                    item.IsHidden = true;
+                    foreach (PointerRef pr in new List<dynamic> { (PointerRef)((dynamic)item.Value).Source, (PointerRef)((dynamic)item.Value).Target })
+                    {
+                        if (pr.Type == PointerRefType.External)
+                        {
+                            if (App.AssetManager.GetEbxEntry(pr.External.FileGuid).Name == asset)
+                                item.IsHidden = false;
+                        }
+                    }
+                    if (retVal && !item.IsHidden)
+                        retVal = false;
+                }
+                else
+                {
+                    item.IsHidden = !doNotHideSubObjects;
+                    if (item.Value is PointerRef pr)
+                    {
+                        if (pr.Type == PointerRefType.External)
+                        {
+                            if (App.AssetManager.GetEbxEntry(pr.External.FileGuid) != null && App.AssetManager.GetEbxEntry(pr.External.FileGuid).Name == asset)
+                                item.IsHidden = false;
+                        }
+                    }
+                    if (!item.FilterAsset(asset, refObjects, !item.IsHidden) || !item.IsHidden)
+                        retVal = false;
+                }
+            }
+            if (!retVal)
+            {
+                IsHidden = false;
+            }
+            return retVal;
+        }
+
         public void AddChild(object value, object defValue)
         {
             IList list = (IList)_value;
@@ -1624,6 +1679,14 @@ namespace Frosty.Core.Controls
                     foreach (var item in items)
                     {
                         if (item.FilterGuid(guidValue.ToLower(), refObjects))
+                            item.IsHidden = true;
+                    }
+                }
+                else if (filterText.StartsWith("asset:") && App.AssetManager.GetEbxEntry(filterText.Substring(6)) != null)
+                {
+                    foreach (var item in items)
+                    {
+                        if (item.FilterAsset(filterText.Substring(6), refObjects))
                             item.IsHidden = true;
                     }
                 }

--- a/FrostyPlugin/Handlers/LegacyCustomActionHandler.cs
+++ b/FrostyPlugin/Handlers/LegacyCustomActionHandler.cs
@@ -15,6 +15,8 @@ namespace Frosty.Core.Handlers
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class ModLegacyFileEntry
         {
             public int Hash { get; set; }

--- a/FrostyPlugin/IO/FrostyModWriter.cs
+++ b/FrostyPlugin/IO/FrostyModWriter.cs
@@ -330,7 +330,7 @@ namespace Frosty.Core.IO
                     if (entry.HasModifiedData)
                     {
                         ICustomActionHandler actionHandler = App.PluginManager.GetCustomHandler(entry.Type);
-                        if (actionHandler != null && !entry.IsAdded)
+                        if (actionHandler != null && (!entry.IsAdded || actionHandler.ModifiesAddedAssets == true))
                         {
                             // use custom action handler to save asset to mod
                             actionHandler.SaveToMod(this, entry);

--- a/FrostyPlugin/Mod/IModCustomHandler.cs
+++ b/FrostyPlugin/Mod/IModCustomHandler.cs
@@ -16,6 +16,11 @@ namespace Frosty.Core.Mod
         HandlerUsage Usage { get; }
 
         /// <summary>
+        /// Allows custom handlers to be used on duplicated assets which will make them mergable in FMM.
+        /// </summary>
+        bool ModifiesAddedAssets { get; }
+
+        /// <summary>
         /// Handles the loading and merging of the custom data.
         /// </summary>
         /// <param name="existing">The existing object data that has been loaded from previous mods.</param>

--- a/Plugins/BiowareLocalizationPlugin/BiowareLocalizationCustomActionHandler.cs
+++ b/Plugins/BiowareLocalizationPlugin/BiowareLocalizationCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace BiowareLocalizationPlugin
 
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/BiowareLocalizationPlugin/Controls/ListBoxUtils.cs
+++ b/Plugins/BiowareLocalizationPlugin/Controls/ListBoxUtils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Frosty.Core;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -49,7 +50,14 @@ namespace BiowareLocalizationPlugin.Controls
                     sb.AppendLine(selected.ToString());
                 }
 
-                Clipboard.SetText(sb.ToString());
+                try
+                {
+                    Clipboard.SetText(sb.ToString());
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
             }
         }
     }

--- a/Plugins/DelayLoadBundlePlugin/DAIDelayLoadBundleEditor.cs
+++ b/Plugins/DelayLoadBundlePlugin/DAIDelayLoadBundleEditor.cs
@@ -81,7 +81,14 @@ namespace DelayLoadBundlePlugin
             if (selectedItem == null)
                 return;
 
-            Clipboard.SetText(selectedItem.Hash.ToString());
+            try
+            {
+                Clipboard.SetText(selectedItem.Hash.ToString());
+            }
+            catch
+            {
+                App.Logger.LogError("Could not copy to clipboard. Please retry");
+            }
         }
 
         GridViewColumnHeader lastSortHeader;

--- a/Plugins/DifficultyWeaponTableDataPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
+++ b/Plugins/DifficultyWeaponTableDataPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
@@ -22,6 +22,8 @@ namespace DifficultyWeaponTableDataPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
+++ b/Plugins/DuplicationPlugin/DuplicateContextMenuItem.cs
@@ -89,7 +89,7 @@ namespace DuplicationPlugin
 
                 // Add new bundle
                 BundleEntry oldBundle = App.AssetManager.GetBundleEntry(newEntry.AddedBundles[0]);
-                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + newName.ToLower(), BundleType.BlueprintBundle, oldBundle.SuperBundleId);
+                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + (ProfilesLibrary.DataVersion == (int)ProfileVersion.StarWarsBattlefrontII ? newName : newName.ToLower()), BundleType.BlueprintBundle, oldBundle.SuperBundleId);
 
                 newEntry.AddedBundles.Clear();
                 newEntry.AddedBundles.Add(App.AssetManager.GetBundleId(newBundle));
@@ -111,7 +111,7 @@ namespace DuplicationPlugin
 
                 // Add new bundle
                 BundleEntry oldBundle = App.AssetManager.GetBundleEntry(newEntry.AddedBundles[0]);
-                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + newName.ToLower(), BundleType.SubLevel, oldBundle.SuperBundleId);
+                BundleEntry newBundle = App.AssetManager.AddBundle("win32/" + (ProfilesLibrary.DataVersion == (int)ProfileVersion.StarWarsBattlefrontII ? newName : newName.ToLower()), BundleType.SubLevel, oldBundle.SuperBundleId);
 
                 newEntry.AddedBundles.Clear();
                 newEntry.AddedBundles.Add(App.AssetManager.GetBundleId(newBundle));
@@ -280,7 +280,7 @@ namespace DuplicationPlugin
             {
                 //2017 battlefront meshes always have lowercase names. This doesn't apply to all games, but its still safer to do so
                 newName = newName.ToLower();
-                
+
                 // Duplicate the ebx
                 EbxAssetEntry newEntry = base.DuplicateAsset(entry, newName, createNew, newType);
                 EbxAsset newAsset = App.AssetManager.GetEbx(newEntry);

--- a/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
+++ b/Plugins/FsLocalizationPlugin/FsLocalizationCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace FsLocalizationPlugin
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class FsLocalizationResource : EditorModResource
         {
             public override ModResourceType Type => ModResourceType.Ebx;

--- a/Plugins/LuaPlugin/CodeEditor/CodeEditor.cs
+++ b/Plugins/LuaPlugin/CodeEditor/CodeEditor.cs
@@ -400,6 +400,15 @@ namespace LuaPlugin.CodeEditor
                 // Cut selection
                 int imin = SelectionStart.Index <= SelectionEnd.Index ? SelectionStart.Index : SelectionEnd.Index;
                 int imax = SelectionStart.Index <= SelectionEnd.Index ? SelectionEnd.Index : SelectionStart.Index;
+
+                try
+                {
+                    Clipboard.SetText(Text.Substring(imin, imax - imin));
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
                 Clipboard.SetText(Text.Substring(imin, imax - imin));
                 ModifyText(imin, imax, "");
                 CaretBlink = true;
@@ -412,7 +421,15 @@ namespace LuaPlugin.CodeEditor
                 // Copy selection
                 int imin = SelectionStart.Index <= SelectionEnd.Index ? SelectionStart.Index : SelectionEnd.Index;
                 int imax = SelectionStart.Index <= SelectionEnd.Index ? SelectionEnd.Index : SelectionStart.Index;
-                Clipboard.SetText(Text.Substring(imin, imax - imin));
+
+                try
+                {
+                    Clipboard.SetText(Text.Substring(imin, imax - imin));
+                }
+                catch
+                {
+                    App.Logger.LogError("Could not copy to clipboard. Please retry");
+                }
                 CaretBlink = true;
                 InvalidateVisual();
             }

--- a/Plugins/MeshSetPlugin/Handlers/ShaderBlockDepotCustomActionHandler.cs
+++ b/Plugins/MeshSetPlugin/Handlers/ShaderBlockDepotCustomActionHandler.cs
@@ -13,6 +13,8 @@ namespace MeshSetPlugin.Handlers
     {
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         private class ShaderBlockDepotResource : EditorModResource
         {
             public static uint Hash => 0x89ef2205;

--- a/Plugins/TestPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
+++ b/Plugins/TestPlugin/Handlers/DifficultyWeaponTableActionHandler.cs
@@ -18,6 +18,8 @@ namespace TestPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Merge;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This

--- a/Plugins/TestPlugin/Handlers/SvgImageCustomActionHandler.cs
+++ b/Plugins/TestPlugin/Handlers/SvgImageCustomActionHandler.cs
@@ -18,6 +18,8 @@ namespace TestPlugin.Handlers
         // data from one mod with another, or does it merge the two together.
         public HandlerUsage Usage => HandlerUsage.Modify;
 
+        public bool ModifiesAddedAssets => false;
+
         // A mod is comprised of a series of base resources, embedded, ebx, res, and chunks. Embedded are used internally
         // for the icon and images of a mod. Ebx/Res/Chunks are the core resources used for applying data to the game.
         // When you create a custom handler, you need to provide your own resources for your custom handled data. This


### PR DESCRIPTION
Paste Shallow: Currently Frosty always pastes a deep copy of every object. A shallow copy is the same except all Pointer Refs (references to other objects) will remain the same as the copied object.
Paste Reference: Instead of pasting an object you will paste a reference to it.