### PR TITLE
[Editor & ModManager] 1.0.6.3 Remember Profile bug

### DIFF
--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -191,17 +191,25 @@ namespace FrostyEditor
                     {
                         defaultConfig = new FrostyConfiguration(prof);
                     }
-                    catch (System.IO.FileNotFoundException)
+                    catch (FileNotFoundException)
                     {
+                        defaultConfig = null;
                         Config.RemoveGame(prof); // couldn't find the exe, so remove it from the profile list
+                        Config.Remove("DefaultProfile");
+                        Config.Save();
+                    }
+                    catch 
+                    {
+                        defaultConfig = null;
+                        Config.Remove("DefaultProfile");
                         Config.Save();
                     }
                 }
-                else
-                {
-                    Config.Add("UseDefaultProfile", false);
-                    Config.Save();
-                }
+//                else
+//                {
+//                    Config.Add("UseDefaultProfile", false);
+//                    Config.Save();
+//                }
             }
 
             //check args to see if it is loading a project
@@ -236,17 +244,21 @@ namespace FrostyEditor
 
             if (defaultConfig != null)
             {
-                // load profile
-                if (!ProfilesLibrary.Initialize(defaultConfig.ProfileName))
+                try
                 {
-                    FrostyMessageBox.Show("There was an error when trying to load game using specified profile.", "Frosty Editor");
-                    return;
+                    // load profile
+                    if (!ProfilesLibrary.Initialize(defaultConfig.ProfileName))
+                    {
+                        FrostyMessageBox.Show("There was an error when trying to load game using specified profile.", "Frosty Editor");
+                        return;
+                    }
+
+                    this.StartupUri = new System.Uri("/FrostyEditor;component/Windows/SplashWindow.xaml", System.UriKind.Relative);
+
+                    App.InitDiscordRPC();
+                    App.UpdateDiscordRPC("Loading...");
                 }
-
-                this.StartupUri = new System.Uri("/FrostyEditor;component/Windows/SplashWindow.xaml", System.UriKind.Relative);
-
-                App.InitDiscordRPC();
-                App.UpdateDiscordRPC("Loading...");
+                catch { }
             }
         }
 

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -205,11 +205,6 @@ namespace FrostyEditor
                         Config.Save();
                     }
                 }
-//                else
-//                {
-//                    Config.Add("UseDefaultProfile", false);
-//                    Config.Save();
-//                }
             }
 
             //check args to see if it is loading a project

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -258,7 +258,12 @@ namespace FrostyEditor
                     App.InitDiscordRPC();
                     App.UpdateDiscordRPC("Loading...");
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Config.Remove("DefaultProfile");
+                    Config.Save();
+                    throw ex;
+                }
             }
         }
 

--- a/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
@@ -9,10 +9,6 @@ using FrostySdk;
 using Microsoft.Win32;
 using Frosty.Controls;
 using Frosty.Core;
-using Frosty.Core.Windows;
-using System.Threading;
-using FrostySdk.Interfaces;
-using System.Linq;
 
 namespace FrostyEditor.Windows
 {
@@ -143,79 +139,32 @@ namespace FrostyEditor.Windows
 
         private void ScanForGamesButton_Click(object sender, RoutedEventArgs e)
         {
-            // setup ability to cancel
-            CancellationTokenSource cancelToken = new CancellationTokenSource();
-
-            try
+            using (RegistryKey lmKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\WOW6432Node"))
             {
-                FrostyTaskWindow.Show("Scanning for games", "", (task) =>
-                {
-                    try
-                    {
-                        using (RegistryKey lmKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\WOW6432Node"))
-                        {
-                            cancelToken.Token.ThrowIfCancellationRequested();
-                            int totalCount = 0;
-                            IterateSubKeys(lmKey, ref totalCount, cancelToken.Token, task.TaskLogger, null);
-                        }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        App.Logger.Log("Scan Game Cancelled");
-                    }
-                    
+                int totalCount = 0;
 
-                }, showCancelButton: true, cancelCallback: (task) => cancelToken.Cancel());
-            }
-            catch (OperationCanceledException)
-            {
-                App.Logger.Log("Scan Game Cancelled");
+                IterateSubKeys(lmKey, ref totalCount);
             }
 
             ConfigList.Items.Refresh();
         }
 
-        private void IterateSubKeys(RegistryKey subKey, ref int totalCount, CancellationToken cancelToken, ILogger inLogger, int? subKeyCount)
+        private void IterateSubKeys(RegistryKey subKey, ref int totalCount)
         {
-            int index = 0;
-            bool isFirstLoop = false;
-            if (subKeyCount == null)
-            {
-                subKeyCount = subKey.GetSubKeyNames().Length;
-                isFirstLoop = true;
-            }
-
             foreach (string subKeyName in subKey.GetSubKeyNames())
             {
-                cancelToken.ThrowIfCancellationRequested();
                 try
                 {
-                    if (isFirstLoop == true)
-                    {
-                        index++;
-                        inLogger.Log("progress:" + (float)index / (float)subKeyCount * 100d);
-                        Thread.Sleep(1);
-                    }
-                    inLogger.Log("Checking: " + subKeyName);
-
-                    if (subKeyName == "Microsoft")
-                    {
-                        continue;
-                    }
-
-                    IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount, cancelToken, inLogger, subKeyCount);
+                    IterateSubKeys(subKey.OpenSubKey(subKeyName), ref totalCount);
                 }
                 catch (System.Exception)
                 {
                     continue;
                 }
             }
-            cancelToken.ThrowIfCancellationRequested();
 
             foreach (string subKeyValue in subKey.GetValueNames())
             {
-                cancelToken.ThrowIfCancellationRequested();
-
                 if (subKeyValue.IndexOf("Install Dir", StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     string installDir = subKey.GetValue("Install Dir") as string;
@@ -224,12 +173,8 @@ namespace FrostyEditor.Windows
                     if (!Directory.Exists(installDir))
                         continue;
 
-                    cancelToken.ThrowIfCancellationRequested(); 
-
                     foreach (string filename in Directory.EnumerateFiles(installDir, "*.exe"))
                     {
-                        cancelToken.ThrowIfCancellationRequested();
-
                         FileInfo fi = new FileInfo(filename);
                         string nameWithoutExt = fi.Name.Replace(fi.Extension, "");
 

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -143,11 +143,6 @@ namespace FrostyModManager
                         Config.Save();
                     }
                 }
-//                else
-//                {
-//                    Config.Add("UseDefaultProfile", false);
-//                    Config.Save();
-//                }
             } 
             //foreach (FrostyConfiguration name in configs)
             //{

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -129,18 +129,26 @@ namespace FrostyModManager
                     {
                         defaultConfig = new FrostyConfiguration(prof);
                     }
-                    catch (System.IO.FileNotFoundException)
+                    catch (FileNotFoundException)
                     {
+                        defaultConfig = null;
                         Config.RemoveGame(prof); // couldn't find the exe, so remove it from the profile list
+                        Config.Remove("DefaultProfile");
+                        Config.Save();
+                    }
+                    catch
+                    {
+                        defaultConfig = null;
+                        Config.Remove("DefaultProfile");
                         Config.Save();
                     }
                 }
-                else
-                {
-                    Config.Add("UseDefaultProfile", false);
-                    Config.Save();
-                }
-            }
+//                else
+//                {
+//                    Config.Add("UseDefaultProfile", false);
+//                    Config.Save();
+//                }
+            } 
             //foreach (FrostyConfiguration name in configs)
             //{
             //    if (name.ProfileName == defaultConfigname)
@@ -152,14 +160,18 @@ namespace FrostyModManager
             // Launches the Frosty Mod Manager is there is a Default Config
             if (defaultConfig != null)
             {
-                // load profile
-                if (!ProfilesLibrary.Initialize(defaultConfig.ProfileName))
+                try
                 {
-                    FrostyMessageBox.Show("There was an error when trying to load game using specified profile.", "Frosty Mod Manager");
-                    return;
-                }
+                    // load profile
+                    if (!ProfilesLibrary.Initialize(defaultConfig.ProfileName))
+                    {
+                        FrostyMessageBox.Show("There was an error when trying to load game using specified profile.", "Frosty Mod Manager");
+                        return;
+                    }
 
-                StartupUri = new Uri("/FrostyModManager;component/Windows/SplashWindow.xaml", System.UriKind.Relative);
+                    StartupUri = new Uri("/FrostyModManager;component/Windows/SplashWindow.xaml", System.UriKind.Relative);
+                }
+                catch { }
             }
             //if (defaultConfig != null)
             //{

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -171,7 +171,12 @@ namespace FrostyModManager
 
                     StartupUri = new Uri("/FrostyModManager;component/Windows/SplashWindow.xaml", System.UriKind.Relative);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Config.Remove("DefaultProfile");
+                    Config.Save();
+                    throw ex;
+                }
             }
             //if (defaultConfig != null)
             //{


### PR DESCRIPTION
When the default selected game is removed, an exception will occur start from the second launch

Reproduction method:
1. start frosty and make sure `Remember Profile Choice` is enabled  
close frosty
2. remove default game (just need to move game.exe away)  
3. start frosty  
close frosty
(Profile will be removed now)
4. start frosty (exception here)
(Profile is removed and cannot be found)
<details><summary>Exception</summary>
<p>

```
The given key was not present in the dictionary.

   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Frosty.Core.Config.get_Item(String option, ConfigScope scope, String profile) in Path-to-repo:\FrostyToolsuite\SuperCheatedFrostyToolsuite\FrostyPlugin\Config.cs:line 242
   at Frosty.Core.Config.Get[T](String option, T defaultValue, ConfigScope scope, String profile) in Path-to-repo:\FrostyToolsuite\SuperCheatedFrostyToolsuite\FrostyPlugin\Config.cs:line 215
   at Frosty.Core.FrostyConfiguration..ctor(String profile) in Path-to-repo:\FrostyToolsuite\SuperCheatedFrostyToolsuite\FrostyPlugin\FrostyConfiguration.cs:line 25
   at FrostyModManager.App.Application_Startup(Object sender, StartupEventArgs e) in Path-to-repo:\FrostyToolsuite\SuperCheatedFrostyToolsuite\FrostyModManager\App.xaml.cs:line 130
   at System.Windows.Application.OnStartup(StartupEventArgs e)
   at System.Windows.Application.<.ctor>b__1_0(Object unused)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
``` 

</p>
</details> 

This bug can be solved manually by deleting `"DefaultProfile"` in config.json