### PR TITLE
fix epic! issue with thread unsafe hashset

### DIFF
--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -261,7 +261,7 @@ namespace Frosty.ModSupport
             }
 
 
-            Parallel.ForEach(fmod.Resources, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount }, resource =>
+            Parallel.ForEach(fmod.Resources, resource =>
             {
                 // pull existing bundles from asset manager
                 HashSet<int> bundles = new HashSet<int>();
@@ -272,7 +272,8 @@ namespace Frosty.ModSupport
                     resource.FillAssetEntry(bEntry);
 
                     addedBundles.TryAdd(bEntry.SuperBundleId, new HashSet<string>());
-                    addedBundles[bEntry.SuperBundleId].Add(bEntry.Name);
+                    lock (addedBundles[bEntry.SuperBundleId])
+                        addedBundles[bEntry.SuperBundleId].Add(bEntry.Name);
                 }
                 else if (resource.Type == ModResourceType.Ebx)
                 {

--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -272,8 +272,12 @@ namespace Frosty.ModSupport
                     resource.FillAssetEntry(bEntry);
 
                     addedBundles.TryAdd(bEntry.SuperBundleId, new HashSet<string>());
-                    lock (addedBundles[bEntry.SuperBundleId])
-                        addedBundles[bEntry.SuperBundleId].Add(bEntry.Name);
+
+                    HashSet<string> addedBundlesSet = addedBundles[bEntry.SuperBundleId];
+                    lock (addedBundlesSet)
+                    {
+                        addedBundlesSet.Add(bEntry.Name);
+                    }
                 }
                 else if (resource.Type == ModResourceType.Ebx)
                 {


### PR DESCRIPTION
fixes unavoidable and random crashes due to null strings in the hashset

![2023-11-07_22-05-48_devenv](https://github.com/CadeEvs/FrostyToolsuite/assets/13797470/72c1e3fa-78ea-4d24-960b-c021e4d66b6b)
