### PR TITLE
Fix issue with EnumerateRes ignoring AddedBundles

### DIFF
--- a/FrostySdk/Managers/AssetManager.cs
+++ b/FrostySdk/Managers/AssetManager.cs
@@ -1429,6 +1429,11 @@ namespace FrostySdk.Managers
                             bFound = true;
                             break;
                         }
+                        else if (entry.AddedBundles.Contains(bindex))
+                        {
+                            bFound = true;
+                            break;
+                        }
                     }
                     if (!bFound)
                         continue;


### PR DESCRIPTION
This fixes an issue with AssetManager.EnumerateRes(uint resType, bool modifiedOnly, params int[] bundles) ignoring added bundles, meaning an asset can be in a bundle yet this will ignore it.