### PR TITLE
Add automatic updating of mesh bounding box when importing, view centering improvements

### DIFF
--- a/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
+++ b/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
@@ -4486,7 +4486,6 @@ namespace MeshSetPlugin
                     // update UI
                     screen.ClearMeshes(clearAll: true);
                     screen.AddMesh(meshSet, GetVariation(selectedPreviewIndex), Matrix.Identity /*Matrix.Scaling(1,1,-1)*/, LoadPose(AssetEntry.Filename, asset));
-                    screen.CenterView();
 
                     UpdateMeshSettings();
                     UpdateControls();

--- a/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
+++ b/Plugins/MeshSetPlugin/FrostyMeshSetEditor.cs
@@ -164,7 +164,6 @@ namespace MeshSetPlugin
         [EbxFieldMeta(EbxFieldType.Struct, "", EbxFieldType.Inherited)]
         public MeshAssetBoundingBox BoundingBox { get; set; } = new MeshAssetBoundingBox();
 
-
         [Category("Mesh")]
         [EbxFieldMeta(EbxFieldType.Struct)]
         public List<PreviewMeshLodData> Lods { get; set; } = new List<PreviewMeshLodData>();
@@ -3877,7 +3876,7 @@ namespace MeshSetPlugin
 
             foreach (MeshSetLod lod in meshSet.Lods)
             {
-                PreviewMeshLodData lodData = new PreviewMeshLodData() { Name = lod.ShortName};
+                PreviewMeshLodData lodData = new PreviewMeshLodData() { Name = lod.ShortName };
                 foreach (MeshSetSection section in lod.Sections)
                 {
                     if (lod.IsSectionRenderable(section) && section.PrimitiveCount > 0)
@@ -4487,6 +4486,7 @@ namespace MeshSetPlugin
                     // update UI
                     screen.ClearMeshes(clearAll: true);
                     screen.AddMesh(meshSet, GetVariation(selectedPreviewIndex), Matrix.Identity /*Matrix.Scaling(1,1,-1)*/, LoadPose(AssetEntry.Filename, asset));
+                    screen.CenterView();
 
                     UpdateMeshSettings();
                     UpdateControls();

--- a/Plugins/MeshSetPlugin/Render/MeshRenderMesh.cs
+++ b/Plugins/MeshSetPlugin/Render/MeshRenderMesh.cs
@@ -20,6 +20,11 @@ namespace MeshSetPlugin.Render
                 lods.Add(renderLod);
             }
 
+            UpdateBounds(meshSet);
+        }
+
+        public void UpdateBounds(MeshSet meshSet)
+        {
             Bounds = new BoundingBox(
                 new Vector3(meshSet.BoundingBox.min.x, meshSet.BoundingBox.min.y, meshSet.BoundingBox.min.z),
                 new Vector3(meshSet.BoundingBox.max.x, meshSet.BoundingBox.max.y, meshSet.BoundingBox.max.z)

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -1594,7 +1594,7 @@ namespace MeshSetPlugin.Resources
         }
 
         private TangentSpaceCompressionType m_tangentSpaceCompressionType;
-        public AxisAlignedBox m_boundingBox;
+        private AxisAlignedBox m_boundingBox;
         private string m_fullname;
         private string m_name;
         private uint m_nameHash;

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -1531,7 +1531,7 @@ namespace MeshSetPlugin.Resources
                 }
             }
         }
-        public AxisAlignedBox BoundingBox => m_boundingBox;
+        public AxisAlignedBox BoundingBox { get => m_boundingBox; set => m_boundingBox = value; }
         public List<MeshSetLod> Lods => m_lods;
         public MeshType Type { get => m_meshType; set => m_meshType = value; }
         public MeshSetLayoutFlags Flags => m_flags;
@@ -1594,7 +1594,7 @@ namespace MeshSetPlugin.Resources
         }
 
         private TangentSpaceCompressionType m_tangentSpaceCompressionType;
-        private AxisAlignedBox m_boundingBox;
+        public AxisAlignedBox m_boundingBox;
         private string m_fullname;
         private string m_name;
         private uint m_nameHash;

--- a/Plugins/MeshSetPlugin/Screens/MultiMeshPreviewScreen.cs
+++ b/Plugins/MeshSetPlugin/Screens/MultiMeshPreviewScreen.cs
@@ -376,6 +376,7 @@ namespace MeshSetPlugin.Screens
 
             foreach (MeshAndPreviewContainer mesh in renderMeshes)
             {
+                mesh.Preview.UpdateBounds(mesh.Mesh); //update bb before we calc anything, means we can reset the view when a mesh is imported!
                 BoundingBox bb = mesh.Preview.Bounds;
                 bb.Minimum = (bb.Minimum + mesh.Transform.TranslationVector) * new Vector3(-1, 1, 1);
                 bb.Maximum = (bb.Maximum + mesh.Transform.TranslationVector) * new Vector3(-1, 1, 1);


### PR DESCRIPTION
- MeshSet AABB is now updated when importing a custom mesh
- You can now view the MeshSet AABB in the Mesh tab (mostly for debugging, its readonly, but nice to have ig)
- Slight refactor of viewport bb code to have an update method, this is used when centering the view so it will actually center to the correct point after a custom mesh is imported without reopening the asset