### PR TITLE
Add AssetClassGuid overload to EbxAsset.GetObject

### DIFF
--- a/FrostySdk/IO/EbxReader.cs
+++ b/FrostySdk/IO/EbxReader.cs
@@ -237,9 +237,29 @@ namespace FrostySdk.IO
         {
         }
 
+        /// <summary>
+        /// Enumerates over exported objects in an EbxAsset until an object with the specified guid is found
+        /// </summary>
+        /// <param name="guid"></param>
+        /// <returns>An object with a matching Exported Guid. Null if none found</returns>
         public dynamic GetObject(Guid guid)
         {
             foreach (dynamic obj in ExportedObjects)
+            {
+                if (obj.GetInstanceGuid() == guid)
+                    return obj;
+            }
+            return null;
+        }
+        
+        /// <summary>
+        /// Enumerates over all objects in an EbxAsset until an object with the specified guid is found
+        /// </summary>
+        /// <param name="guid"></param>
+        /// <returns>An object with a matching AssetClassGuid. Null if none found</returns>
+        public dynamic GetObject(AssetClassGuid guid)
+        {
+            foreach (dynamic obj in Objects)
             {
                 if (obj.GetInstanceGuid() == guid)
                     return obj;

--- a/FrostySdk/Managers/AssetManager.cs
+++ b/FrostySdk/Managers/AssetManager.cs
@@ -1429,6 +1429,11 @@ namespace FrostySdk.Managers
                             bFound = true;
                             break;
                         }
+                        else if (entry.AddedBundles.Contains(bindex))
+                        {
+                            bFound = true;
+                            break;
+                        }
                     }
                     if (!bFound)
                         continue;


### PR DESCRIPTION
- Adds an overload to EbxAsset.Getobject() for enumerating over all objects via an AssetClassGuid instead of just exported
- Adds documentation to both methods to clarify