### PR TITLE
[Solution] Stop auto compile plugins and fix xcopy bug

### DIFF
--- a/FrostyEditor/FrostyEditor.sln
+++ b/FrostyEditor/FrostyEditor.sln
@@ -4,10 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.5.33318.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrostyEditor", "FrostyEditor.csproj", "{355B078B-45A5-472D-9CCD-688D8E30BAED}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5FDD1243-084E-42DC-99BB-394A169D988F} = {5FDD1243-084E-42DC-99BB-394A169D988F}
-		{29189DBC-1D9C-4760-960E-805B60211401} = {29189DBC-1D9C-4760-960E-805B60211401}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrostySdk", "..\FrostySdk\FrostySdk.csproj", "{93FB4A0C-DF89-4169-80B5-C4E2277FF7A0}"
 EndProject

--- a/Plugins/AtlasTexturePlugin/AtlasTexturePlugin.csproj
+++ b/Plugins/AtlasTexturePlugin/AtlasTexturePlugin.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/BiowareLocalizationPlugin/BiowareLocalizationPlugin.csproj
+++ b/Plugins/BiowareLocalizationPlugin/BiowareLocalizationPlugin.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
-		<Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\"' />
 	</Target>
   
   <ItemGroup>

--- a/Plugins/BlankPlugin/BlankPlugin.csproj
+++ b/Plugins/BlankPlugin/BlankPlugin.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/BundleEditorPlugin/BundleEditorPlugin.csproj
+++ b/Plugins/BundleEditorPlugin/BundleEditorPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/ChunkResExplorerPlugin/ChunkResEditorPlugin.csproj
+++ b/Plugins/ChunkResExplorerPlugin/ChunkResEditorPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/ConnectionPlugin/ConnectionPlugin.csproj
+++ b/Plugins/ConnectionPlugin/ConnectionPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/ConversationPlugin/ConversationPlugin.csproj
+++ b/Plugins/ConversationPlugin/ConversationPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/DelayLoadBundlePlugin/DelayLoadBundlePlugin.csproj
+++ b/Plugins/DelayLoadBundlePlugin/DelayLoadBundlePlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/DifficultyWeaponTableDataPlugin/DifficultyWeaponTableDataPlugin.csproj
+++ b/Plugins/DifficultyWeaponTableDataPlugin/DifficultyWeaponTableDataPlugin.csproj
@@ -63,8 +63,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
-		<Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/DuplicationPlugin/DuplicationPlugin.csproj
+++ b/Plugins/DuplicationPlugin/DuplicationPlugin.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/EbxToXmlPlugin/EbxToXmlPlugin.csproj
+++ b/Plugins/EbxToXmlPlugin/EbxToXmlPlugin.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/Fifa/LegacyBigFilePlugin/LegacyBigFilePlugin.csproj
+++ b/Plugins/Fifa/LegacyBigFilePlugin/LegacyBigFilePlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/Fifa/LegacyDatabasePlugin/LegacyDatabasePlugin.csproj
+++ b/Plugins/Fifa/LegacyDatabasePlugin/LegacyDatabasePlugin.csproj
@@ -56,6 +56,6 @@
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
 </Project>

--- a/Plugins/Fifa/LegacyDdsPlugin/LegacyDdsPlugin.csproj
+++ b/Plugins/Fifa/LegacyDdsPlugin/LegacyDdsPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/Fifa/LegacyKitPreviewPlugin/LegacyKitPreviewPlugin.csproj
+++ b/Plugins/Fifa/LegacyKitPreviewPlugin/LegacyKitPreviewPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/Fifa/LegacyLocalizedStringsPlugin/LegacyLocalizedStringsPlugin.csproj
+++ b/Plugins/Fifa/LegacyLocalizedStringsPlugin/LegacyLocalizedStringsPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/Fifa/LegacyTextPlugin/LegacyTextPlugin.csproj
+++ b/Plugins/Fifa/LegacyTextPlugin/LegacyTextPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\Fifa\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\Fifa\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/FsLocalizationPlugin/FsLocalizationPlugin.csproj
+++ b/Plugins/FsLocalizationPlugin/FsLocalizationPlugin.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/IesResourcePlugin/IesResourcePlugin.csproj
+++ b/Plugins/IesResourcePlugin/IesResourcePlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/LaunchPlatformPlugin/LaunchPlatformPlugin.csproj
+++ b/Plugins/LaunchPlatformPlugin/LaunchPlatformPlugin.csproj
@@ -60,7 +60,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\&#xD;&#xA;xcopy /Y $(TargetPath) C:\Frostbite\FrostyToolsSuite\FrostyToolSuite_Current-v1.0.6\FrostyToolSuite_Current\FrostyModManager\bin\Developer\Debug\Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/LocalizedStringPlugin/LocalizedStringPlugin.csproj
+++ b/Plugins/LocalizedStringPlugin/LocalizedStringPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/LuaPlugin/LuaPlugin.csproj
+++ b/Plugins/LuaPlugin/LuaPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/MeshSetPlugin/MeshSetPlugin.csproj
+++ b/Plugins/MeshSetPlugin/MeshSetPlugin.csproj
@@ -44,8 +44,8 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)..\FrostyModManager\$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/ObjectVariationPlugin/ObjectVariationPlugin.csproj
+++ b/Plugins/ObjectVariationPlugin/ObjectVariationPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/ReferencesPlugin/ReferencesPlugin.csproj
+++ b/Plugins/ReferencesPlugin/ReferencesPlugin.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/RefreshMeshVariationsPlugin/RefreshMeshVariationsPlugin.csproj
+++ b/Plugins/RefreshMeshVariationsPlugin/RefreshMeshVariationsPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/RootInstanceEntriesPlugin/RootInstanceEntriesPlugin.csproj
+++ b/Plugins/RootInstanceEntriesPlugin/RootInstanceEntriesPlugin.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
 
 </Project>

--- a/Plugins/SoundEditorPlugin/SoundEditorPlugin.csproj
+++ b/Plugins/SoundEditorPlugin/SoundEditorPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/SvgImagePlugin/SvgImagePlugin.csproj
+++ b/Plugins/SvgImagePlugin/SvgImagePlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/TestPlugin/TestPlugin.csproj
+++ b/Plugins/TestPlugin/TestPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/TexturePlugin/TexturePlugin.csproj
+++ b/Plugins/TexturePlugin/TexturePlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/TypeExplorerPlugin/TypeExplorerPlugin.csproj
+++ b/Plugins/TypeExplorerPlugin/TypeExplorerPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>

--- a/Plugins/VersionDataPlugin/VersionDataPlugin.csproj
+++ b/Plugins/VersionDataPlugin/VersionDataPlugin.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y $(TargetPath) $(SolutionDir)$(OutDir)Plugins\" />
+    <Exec Command='xcopy /Y "$(TargetPath)" "$(SolutionDir)$(OutDir)Plugins\"' />
   </Target>
   
   <ItemGroup>


### PR DESCRIPTION
- Fixed that `SoundEditorPlugin` and `VersionDataPlugin` will be automatically compiled when **FrostyEditor** is compiled
- Add `""` for `xcopy` in all plugins. Without `""`, `xcopy` will exit with code 4 if copy path have space
  
btw `LaunchPlatformPlugin` and `BlankPlugin` and `TestPlugin(Example Plugin)` should not be compiled for any release.  
Many **stupid users** are stuck on `LaunchPlatformPlugin` because this plugin is still exist in 1.0.6.3 editor release