### PR TITLE
Fix property grid search crashes

### DIFF
--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -940,7 +940,11 @@ namespace Frosty.Core.Controls
 
                     foreach (FrostyPropertyGridItemData childItem in ProcessClass(tmpValue, tmpDefValue, this))
                     {
-                        _children.Add(childItem);
+                        Application.Current.Dispatcher.Invoke(() =>
+                        {
+                            _children.Add(childItem);
+                        });
+                        
                         if (_valueConverter != null)
                         {
                             childItem.PropertyChanged += (o, e) =>
@@ -969,7 +973,10 @@ namespace Frosty.Core.Controls
 
                         FrostyPropertyGridItemData listItem = new FrostyPropertyGridItemData("[" + i + "]", "[" + i + "]", listValue, listDefValue, this, _flags) {Binding = new ArrayItemValueBinding(list, i)};
                         listItem.Attributes.AddRange(Attributes);
-                        _children.Add(listItem);
+                        Application.Current.Dispatcher.Invoke(() =>
+                        {
+                            _children.Add(listItem);
+                        });
                     }
                 }
                 else if (tmpValue is PointerRef pr)
@@ -979,7 +986,12 @@ namespace Frosty.Core.Controls
                         object defValue = (pr.Internal != null) ? Activator.CreateInstance(pr.Internal.GetType()) : null;
 
                         foreach (FrostyPropertyGridItemData childItem in ProcessClass(pr.Internal, defValue, this))
-                            _children.Add(childItem);
+                        {
+                            Application.Current.Dispatcher.Invoke(() =>
+                            {
+                                _children.Add(childItem);
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes an issue where the ProcessChildren() method could be on a different thread to the ObservableCollection _children(which is on the WPF Rendering thread), causing a crash.