### PR TITLE
[Core] Display English exception in ExceptionBox

### DIFF
--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -77,7 +77,6 @@ namespace FrostyEditor
                 if (project.IsDirty)
                 {
                     string name = project.DisplayName.Replace(".fbproject", "");
-                    DateTime timeStamp = DateTime.Now;
 
                     project.Filename = "Autosave/" + name + "_" + DateTime.Now.ToString("ddMMyyyy_HHmmss") + ".fbproject";
                     project.Save();

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -79,17 +79,17 @@ namespace FrostyEditor
                     string name = project.DisplayName.Replace(".fbproject", "");
                     DateTime timeStamp = DateTime.Now;
 
-                    project.Filename = "Autosave/" + name + "_" + timeStamp.Day.ToString("D2") + timeStamp.Month.ToString("D2") + timeStamp.Year.ToString("D4") + "_" + timeStamp.Hour.ToString("D2") + timeStamp.Minute.ToString("D2") + timeStamp.Second.ToString("D2") + ".fbproject";
+                    project.Filename = "Autosave/" + name + "_" + DateTime.Now.ToString("ddMMyyyy_HHmmss") + ".fbproject";
                     project.Save();
                 }
             }
 
             Exception exp = e.Exception;
-            using (NativeWriter writer = new NativeWriter(new FileStream("crashlog.txt", FileMode.Create)))
-                writer.WriteLine($"{exp.Message}\r\n\r\n{exp.StackTrace}");
 
-            FrostyExceptionBox.Show(exp, "Frosty Editor");
-            Environment.Exit(0);
+            if (FrostyExceptionBox.Show(exp, "Frosty Editor") == MessageBoxResult.Cancel)
+                App.Logger.LogWarning("Exception ignored, unknown error may occur");
+            else
+                Environment.Exit(-1);
         }
 
         private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)

--- a/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
@@ -47,7 +47,6 @@ namespace FrostyEditor.Windows
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            throw new Exception("This is a custom exception message\r\nthat have two lines.");
             RefreshConfigurationList();
 
             RemoveConfigButton.IsEnabled = false;

--- a/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
+++ b/FrostyEditor/Windows/PrelaunchWindow2.xaml.cs
@@ -47,6 +47,7 @@ namespace FrostyEditor.Windows
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            throw new Exception("This is a custom exception message\r\nthat have two lines.");
             RefreshConfigurationList();
 
             RemoveConfigButton.IsEnabled = false;

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -76,11 +76,10 @@ namespace FrostyModManager
         {
             Exception exp = e.Exception;
 
-            using (NativeWriter writer = new NativeWriter(new FileStream("crashlog.txt", FileMode.Create)))
-                writer.WriteLine($"{exp.Message}\r\n\r\n{exp.StackTrace}");
-
-            FrostyExceptionBox.Show(exp, "Frosty Mod Manager");
-            Environment.Exit(0);
+            if (FrostyExceptionBox.Show(exp, "Frosty Mod Manager") == MessageBoxResult.Cancel)
+                App.Logger.LogWarning("Exception ignored, unknown error may occur");
+            else
+                Environment.Exit(-1);
         }
 
         private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)

--- a/FrostyPlugin/Controls/FrostyExceptionBox.cs
+++ b/FrostyPlugin/Controls/FrostyExceptionBox.cs
@@ -163,7 +163,7 @@ namespace Frosty.Core.Controls
             {
                 // Call UnlocalizedExceptionGenerator to get exception message in English
                 UnlocalizedExceptionGenerator ueg = new UnlocalizedExceptionGenerator(ex, Thread.CurrentThread.CurrentUICulture);
-                Thread thread = new Thread(ueg.Unloc)
+                Thread thread = new Thread(ueg.Run)
                 {
                     CurrentCulture = CultureInfo.InvariantCulture,
                     CurrentUICulture = CultureInfo.InvariantCulture
@@ -212,7 +212,7 @@ namespace Frosty.Core.Controls
                 _origCultureInfo = origCultureInfo;
             }
 
-            public void Unloc()
+            public void Run()
             {
                 StringBuilder sb = new StringBuilder();
                 sb.Append("Type=");

--- a/FrostyPlugin/Controls/FrostyExceptionBox.cs
+++ b/FrostyPlugin/Controls/FrostyExceptionBox.cs
@@ -171,6 +171,8 @@ namespace Frosty.Core.Controls
                 StringBuilder sb = new StringBuilder();
                 sb.Append("Type=");
                 sb.AppendLine(ex.GetType().ToString());
+                sb.Append("HResult=");
+                sb.AppendLine("0x" + ex.HResult.ToString("X"));
                 sb.Append("Message=");
                 sb.AppendLine(ex.Message);
                 sb.Append("Source=");
@@ -200,6 +202,8 @@ namespace Frosty.Core.Controls
                 StringBuilder sb = new StringBuilder();
                 sb.Append("Type=");
                 sb.AppendLine(_ex.GetType().ToString());
+                sb.Append("HResult=");
+                sb.AppendLine("0x" + _ex.HResult.ToString("X"));
                 sb.Append("Message=");
 
                 string message = _ex.Message;

--- a/FrostyPlugin/Controls/FrostyExceptionBox.cs
+++ b/FrostyPlugin/Controls/FrostyExceptionBox.cs
@@ -1,21 +1,80 @@
 ﻿using Frosty.Controls;
-using Frosty.Core.Windows;
+using FrostyCore;
 using System;
+using System.Collections;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Resources;
+using System.Text;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Frosty.Core.Controls
 {
+    public class ExceptionBoxClickCommand : ICommand
+    {
+        public event EventHandler CanExecuteChanged {
+            add => CommandManager.RequerySuggested += value;
+            remove => CommandManager.RequerySuggested -= value;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        public void Execute(object parameter)
+        {
+            Button btn = parameter as Button;
+            FrostyExceptionBox parentWin = Window.GetWindow(btn) as FrostyExceptionBox;
+
+            string buttonName = btn.Name;
+
+            if (buttonName == "PART_CopyExceptionButton")
+            {
+                Clipboard.SetText(parentWin.ExceptionText);
+                Clipboard.Flush();
+            }
+            else if (buttonName == "PART_CopyLogButton")
+            {
+                Clipboard.SetText(parentWin.LogText);
+                Clipboard.Flush();
+            }
+            else if (buttonName == "PART_IgnoreButton")
+            {
+                parentWin.isIgnored = true;
+                parentWin.Close();
+            }
+        }
+    }
+
     public class FrostyExceptionBox : FrostyDockableWindow
     {
         #region -- Properties --
 
-        #region -- ExceptionText --
+        public bool isIgnored { get; internal set; } = false;
+
+        #region -- Text --
         public static readonly DependencyProperty ExceptionTextProperty = DependencyProperty.Register("ExceptionText", typeof(string), typeof(FrostyExceptionBox), new PropertyMetadata(""));
         public string ExceptionText
         {
             get => (string)GetValue(ExceptionTextProperty);
             set => SetValue(ExceptionTextProperty, value);
+        }
+
+        public static readonly DependencyProperty ExceptionMessageTextProperty = DependencyProperty.Register("ExceptionMessageText", typeof(string), typeof(FrostyExceptionBox), new PropertyMetadata(""));
+        public string ExceptionMessageText {
+            get => (string)GetValue(ExceptionMessageTextProperty);
+            set => SetValue(ExceptionMessageTextProperty, value);
+        }
+
+        public static readonly DependencyProperty LogTextProperty = DependencyProperty.Register("LogText", typeof(string), typeof(FrostyExceptionBox), new PropertyMetadata(""));
+        public string LogText {
+            get => (string)GetValue(LogTextProperty);
+            set => SetValue(LogTextProperty, value);
         }
         #endregion
 
@@ -49,15 +108,126 @@ namespace Frosty.Core.Controls
             base.OnApplyTemplate();
         }
 
-        public static MessageBoxResult Show(Exception e, string title)
+        public static MessageBoxResult Show(Exception e, string title = "Frosty Toolsuite")
         {
             FrostyExceptionBox window = new FrostyExceptionBox
             {
                 Title = title,
-                ExceptionText = e.Message + "\n\n" + e.StackTrace
+                ExceptionText = UnlocalizeException(e),
+                LogText = (App.Logger as FrostyLogger).LogText,
+                ExceptionMessageText = e.Message
             };
 
-            return (window.ShowDialog() == true) ? MessageBoxResult.OK : MessageBoxResult.Cancel;
+            try
+            {
+                Directory.CreateDirectory($"{Environment.CurrentDirectory}\\CrashLogs");
+                using (StreamWriter writer = new StreamWriter(new FileStream($"{Environment.CurrentDirectory}\\CrashLogs\\{DateTime.Now.ToString("ddMMyyyy_HHmmss")}_{e.Source}.txt", FileMode.Create)))
+                {
+                    writer.WriteLine(window.ExceptionText);
+                    writer.WriteLine("Log:");
+                    writer.WriteLine(window.LogText);
+                }
+            }
+            catch (IOException)
+            {
+                using (StreamWriter writer = new StreamWriter(new FileStream($"crashlog_{DateTime.Now.ToString("ddMMyyyy_HHmmss")}.txt", FileMode.Create)))
+                {
+                    writer.WriteLine(window.ExceptionText);
+                    writer.WriteLine("Log:");
+                    writer.WriteLine((App.Logger as FrostyLogger).LogText);
+                }
+            }
+            catch
+            {
+                App.Logger.LogError("Failed to write crash log");
+            }
+            
+
+            window.ShowDialog();
+
+            if (window.isIgnored) return MessageBoxResult.Cancel;
+            return (window.DialogResult == true) ? MessageBoxResult.OK : MessageBoxResult.No;
+        }
+
+        private static string UnlocalizeException(Exception ex)
+        {
+            try
+            {
+                UnlocalizedExceptionGenerator ueg = new UnlocalizedExceptionGenerator(ex, Thread.CurrentThread.CurrentUICulture);
+                Thread thread = new Thread(ueg.Unloc)
+                {
+                    CurrentCulture = CultureInfo.InvariantCulture,
+                    CurrentUICulture = CultureInfo.InvariantCulture
+                };
+                thread.Start();
+                thread.Join();
+
+                return ueg.ExceptionDetails;
+            }
+            catch
+            {
+                App.Logger.LogError("Failed to translate exception");
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append("Type=");
+                sb.AppendLine(ex.GetType().ToString());
+                sb.Append("Message=");
+                sb.AppendLine(ex.Message);
+                sb.Append("Source=");
+                sb.AppendLine(ex.Source);
+                sb.AppendLine("StackTrace:");
+                sb.AppendLine(ex.StackTrace);
+                return sb.ToString();
+            }
+        }
+
+        // https://stackoverflow.com/questions/209133/exception-messages-in-english
+        private class UnlocalizedExceptionGenerator
+        {
+            private Exception _ex;
+            private CultureInfo _origCultureInfo;
+
+            public string ExceptionDetails;
+
+            public UnlocalizedExceptionGenerator(Exception ex, CultureInfo cultureInfo)
+            {
+                _ex = ex;
+                _origCultureInfo = cultureInfo;
+            }
+
+            public void Unloc()
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("Type=");
+                sb.AppendLine(_ex.GetType().ToString());
+                sb.Append("Message=");
+
+                string message = _ex.Message;
+                try
+                {
+                    Assembly assembly = _ex.GetType().Assembly;
+                    ResourceManager rm = new ResourceManager(assembly.GetName().Name, assembly);
+                    ResourceSet originalResources = rm.GetResourceSet(_origCultureInfo, true, true);
+                    ResourceSet targetResources = rm.GetResourceSet(CultureInfo.InvariantCulture, true, true);
+                    foreach (DictionaryEntry originalResource in originalResources)
+                    {
+                        if (originalResource.Value.ToString().Equals(_ex.Message.ToString(), StringComparison.Ordinal))
+                        {
+                            message = targetResources.GetString(originalResource.Key.ToString(), false);
+                            break;
+                        }
+                    }
+                }
+                catch { }
+                sb.AppendLine(message);
+
+                sb.Append("Source=");
+                sb.AppendLine(_ex.Source);
+                sb.AppendLine("StackTrace:");
+                sb.AppendLine(_ex.StackTrace);
+
+                ExceptionDetails = sb.ToString();
+            }
         }
     }
 }

--- a/FrostyPlugin/Controls/FrostyExceptionBox.cs
+++ b/FrostyPlugin/Controls/FrostyExceptionBox.cs
@@ -1,27 +1,21 @@
 ﻿using Frosty.Controls;
-using FrostyCore;
 using System;
-using System.Collections;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Resources;
 using System.Text;
-using System.Threading;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace Frosty.Core.Controls
 {
     /// <summary>
     /// Handle button click
     /// </summary>
-    public class ExceptionBoxClickCommand : ICommand
+    public class ExceptionBoxClickCommand : System.Windows.Input.ICommand
     {
         public event EventHandler CanExecuteChanged {
-            add => CommandManager.RequerySuggested += value;
-            remove => CommandManager.RequerySuggested -= value;
+            add => System.Windows.Input.CommandManager.RequerySuggested += value;
+            remove => System.Windows.Input.CommandManager.RequerySuggested -= value;
         }
 
         public bool CanExecute(object parameter)
@@ -31,7 +25,7 @@ namespace Frosty.Core.Controls
 
         public void Execute(object parameter)
         {
-            Button btn = parameter as Button;
+            System.Windows.Controls.Button btn = parameter as System.Windows.Controls.Button;
             FrostyExceptionBox parentWin = Window.GetWindow(btn) as FrostyExceptionBox;
 
             string buttonName = btn.Name;
@@ -117,7 +111,7 @@ namespace Frosty.Core.Controls
             {
                 Title = title,
                 ExceptionText = UnlocalizeException(e),
-                LogText = (App.Logger as FrostyLogger).LogText,
+                LogText = (App.Logger as FrostyCore.FrostyLogger).LogText,
                 ExceptionMessageText = e.Message
             };
 
@@ -162,8 +156,8 @@ namespace Frosty.Core.Controls
             try
             {
                 // Call UnlocalizedExceptionGenerator to get exception message in English
-                UnlocalizedExceptionGenerator ueg = new UnlocalizedExceptionGenerator(ex, Thread.CurrentThread.CurrentUICulture);
-                Thread thread = new Thread(ueg.Run)
+                UnlocalizedExceptionGenerator ueg = new UnlocalizedExceptionGenerator(ex, System.Threading.Thread.CurrentThread.CurrentUICulture);
+                System.Threading.Thread thread = new System.Threading.Thread(ueg.Run)
                 {
                     CurrentCulture = CultureInfo.InvariantCulture,
                     CurrentUICulture = CultureInfo.InvariantCulture
@@ -225,11 +219,11 @@ namespace Frosty.Core.Controls
                 string message = _ex.Message;
                 try
                 {
-                    Assembly assembly = _ex.GetType().Assembly;
+                    System.Reflection.Assembly assembly = _ex.GetType().Assembly;
                     ResourceManager rm = new ResourceManager(assembly.GetName().Name, assembly);
                     ResourceSet originalResources = rm.GetResourceSet(_origCultureInfo, true, true);
                     ResourceSet targetResources = rm.GetResourceSet(CultureInfo.InvariantCulture, true, true);
-                    foreach (DictionaryEntry originalResource in originalResources)
+                    foreach (System.Collections.DictionaryEntry originalResource in originalResources)
                     {
                         if (originalResource.Value.ToString().Equals(_ex.Message.ToString(), StringComparison.Ordinal))
                         {

--- a/FrostyPlugin/Controls/FrostyExceptionBox.cs
+++ b/FrostyPlugin/Controls/FrostyExceptionBox.cs
@@ -129,7 +129,7 @@ namespace Frosty.Core.Controls
                 {
                     writer.WriteLine(window.ExceptionText);
                     writer.WriteLine("Log:");
-                    writer.WriteLine(window.LogText);
+                    writer.Write(window.LogText);
                 }
             }
             catch (IOException) // Directory maybe in use
@@ -138,7 +138,7 @@ namespace Frosty.Core.Controls
                 {
                     writer.WriteLine(window.ExceptionText);
                     writer.WriteLine("Log:");
-                    writer.WriteLine((App.Logger as FrostyLogger).LogText);
+                    writer.Write(window.LogText);
                 }
             }
             catch

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1420,7 +1420,8 @@
                                 </Grid>
                             </ctrl:FrostyTabItem>
                         </ctrl:FrostyTabControl>
-
+                        
+                        <!-- Header -->
                         <StackPanel Grid.Row="0" Margin="2">
                             <TextBlock Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="16"/>
                             <TextBlock Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1436,7 +1436,7 @@
                         </StackPanel>
                         <StackPanel Grid.Row="2" Margin="8" FlowDirection="LeftToRight" Orientation="Horizontal">
                             <Button x:Name="PART_CopyExceptionButton" Content="Copy Exception" Width="100" Margin="0,0,5,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
-                            <Button x:Name="PART_CopyLogButton" Content="Copy Log" Width="100" Margin="0,0,5,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
+                            <Button x:Name="PART_CopyLogButton" Content="Copy Log" Width="70" Margin="0,0,5,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
                         </StackPanel>
                     </Grid>
                 </DataTemplate>

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1390,25 +1390,52 @@
                 <DataTemplate>
                     <DataTemplate.Resources>
                         <ctrl:WindowCloseCommand x:Key="CloseCommand"/>
+                        <local:ExceptionBoxClickCommand x:Key="exceptionBoxClickCommand" />
                     </DataTemplate.Resources>
 
-                    <Grid Background="{StaticResource ListBackground}">
+                    <Grid Background="#232323">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="26"/>
+                            <RowDefinition Height="40"/>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="38"/>
                         </Grid.RowDefinitions>
 
-                        <!-- Exception has occured text -->
-                        <TextBlock Grid.Row="0" Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="14"/>
+                        <ctrl:FrostyTabControl Grid.Row="1" Margin="0, -12, 0, 0">
+                            <ctrl:FrostyTabItem Header="Exception">
+                                <!-- Crash text -->
+                                <TextBox BorderThickness="1" Padding="4" Text="{Binding ExceptionText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" IsReadOnly="True" FontFamily="Consolas"/>
+                            </ctrl:FrostyTabItem>
 
-                        <!-- Crash text -->
-                        <TextBox Grid.Row="1" Text="{Binding ExceptionText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" IsReadOnly="True" FontFamily="Consolas" Margin="8,0,8,0" BorderThickness="1" Padding="4"/>
+                            <ctrl:FrostyTabItem Header="Log">
+                                <!-- Log -->
+                                <Grid>
+                                    <TextBox BorderThickness="1"
+                                        Padding="4"
+                                        FontFamily="Consolas"
+                                        IsReadOnly="True"
+                                        VerticalScrollBarVisibility="Auto"
+                                        HorizontalScrollBarVisibility="Auto"
+                                        Text="{Binding LogText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}"
+                                        />
+                                </Grid>
+                            </ctrl:FrostyTabItem>
+                        </ctrl:FrostyTabControl>
 
-                        <!-- Ok button -->
+                        <StackPanel Grid.Row="0" Margin="2">
+                            <TextBlock Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="16"/>
+                            <TextBlock Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>
+                        </StackPanel>
+                        
+                        <Border Grid.Row="2" Background="{StaticResource ListBackground}"/>
+                        <!-- Buttons -->
                         <StackPanel Grid.Row="2" Margin="8" FlowDirection="RightToLeft" Orientation="Horizontal">
-                            <Button Content="Ok" Width="75" Command="{StaticResource CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
+                            <Button Content="OK" Width="75" Command="{StaticResource CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
+                            <Button x:Name="PART_IgnoreButton" Content="Ignore" Width="75" Margin="5,0,0,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
                             <!--<Button x:Name="PART_ReportCrashButton" Content="Report Crash" Width="100" Margin="5,0,0,0"/>-->
+                        </StackPanel>
+                        <StackPanel Grid.Row="2" Margin="8" FlowDirection="LeftToRight" Orientation="Horizontal">
+                            <Button x:Name="PART_CopyExceptionButton" Content="Copy Exception" Width="100" Margin="0,0,5,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
+                            <Button x:Name="PART_CopyLogButton" Content="Copy Log" Width="100" Margin="0,0,5,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
                         </StackPanel>
                     </Grid>
                 </DataTemplate>

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1403,7 +1403,7 @@
                         <!-- Header -->
                         <StackPanel Grid.Row="0" Margin="5, 5, 5, 0">
                             <TextBlock Margin="2" Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="16"/>
-                            <TextBlock Margin="2" Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" TextWrapping="WrapWithOverflow" TextTrimming="None" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>
+                            <TextBlock Margin="2, 0, 2, 2" Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" TextWrapping="WrapWithOverflow" TextTrimming="None" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>
                         </StackPanel>
 
                         <TabControl Grid.Row="1" Margin="8,0,8,0">

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1431,7 +1431,7 @@
                         <!-- Buttons -->
                         <StackPanel Grid.Row="2" Margin="8" FlowDirection="RightToLeft" Orientation="Horizontal">
                             <Button Content="OK" Width="75" Command="{StaticResource CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
-                            <Button x:Name="PART_IgnoreButton" Content="Ignore" Width="75" Margin="5,0,0,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
+                            <Button x:Name="PART_IgnoreButton" Content="Ignore" ToolTip="Try to ignore exception, unknown error may occurs" Width="75" Margin="5,0,0,0" Command="{StaticResource exceptionBoxClickCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
                             <!--<Button x:Name="PART_ReportCrashButton" Content="Report Crash" Width="100" Margin="5,0,0,0"/>-->
                         </StackPanel>
                         <StackPanel Grid.Row="2" Margin="8" FlowDirection="LeftToRight" Orientation="Horizontal">

--- a/FrostyPlugin/Themes/Generic.xaml
+++ b/FrostyPlugin/Themes/Generic.xaml
@@ -1393,20 +1393,26 @@
                         <local:ExceptionBoxClickCommand x:Key="exceptionBoxClickCommand" />
                     </DataTemplate.Resources>
 
-                    <Grid Background="#232323">
+                    <Grid Background="{StaticResource ListBackground}">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="40"/>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="38"/>
                         </Grid.RowDefinitions>
 
-                        <ctrl:FrostyTabControl Grid.Row="1" Margin="0, -12, 0, 0">
-                            <ctrl:FrostyTabItem Header="Exception">
+                        <!-- Header -->
+                        <StackPanel Grid.Row="0" Margin="5, 5, 5, 0">
+                            <TextBlock Margin="2" Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="16"/>
+                            <TextBlock Margin="2" Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" TextWrapping="WrapWithOverflow" TextTrimming="None" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>
+                        </StackPanel>
+
+                        <TabControl Grid.Row="1" Margin="8,0,8,0">
+                            <TabItem Header="Exception">
                                 <!-- Crash text -->
                                 <TextBox BorderThickness="1" Padding="4" Text="{Binding ExceptionText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" IsReadOnly="True" FontFamily="Consolas"/>
-                            </ctrl:FrostyTabItem>
+                            </TabItem>
 
-                            <ctrl:FrostyTabItem Header="Log">
+                            <TabItem Header="Log">
                                 <!-- Log -->
                                 <Grid>
                                     <TextBox BorderThickness="1"
@@ -1418,16 +1424,10 @@
                                         Text="{Binding LogText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}"
                                         />
                                 </Grid>
-                            </ctrl:FrostyTabItem>
-                        </ctrl:FrostyTabControl>
+                            </TabItem>
+                        </TabControl>
                         
-                        <!-- Header -->
-                        <StackPanel Grid.Row="0" Margin="2">
-                            <TextBlock Text="An unhandled exception has occurred" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface" FontSize="16"/>
-                            <TextBlock Text="{Binding ExceptionMessageText, RelativeSource={RelativeSource AncestorType={x:Type local:FrostyExceptionBox}}}" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{StaticResource FontColor}" FontFamily="Global User Interface"/>
-                        </StackPanel>
-                        
-                        <Border Grid.Row="2" Background="{StaticResource ListBackground}"/>
+                        <Border Grid.Row="2"/>
                         <!-- Buttons -->
                         <StackPanel Grid.Row="2" Margin="8" FlowDirection="RightToLeft" Orientation="Horizontal">
                             <Button Content="OK" Width="75" Command="{StaticResource CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>


### PR DESCRIPTION
- Change exception format
- Display English exception
- Add log page
- Copy button for exception and log
- Add folder for crash log
- Add log to crash log
- Allow to ignore exception (do not close full app)


<details><summary>Screenshot:</summary>
<p>

(System language is zh-cn)
![图片](https://github.com/CadeEvs/FrostyToolsuite/assets/100991210/489e61cd-8d27-4530-ac7c-6ecfafab4c9e)
Copy Exception:
```
Type=System.Collections.Generic.KeyNotFoundException
Message=The given key was not present in the dictionary.
Source=mscorlib
StackTrace:
   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Frosty.Core.Config.get_Item(String option, ConfigScope scope, String profile) in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyPlugin\Config.cs:line 242
   at Frosty.Core.Config.Get[T](String option, T defaultValue, ConfigScope scope, String profile) in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyPlugin\Config.cs:line 215
   at FrostyModManager.Windows.SplashWindow.<Window_Loaded>d__1.MoveNext() in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyModManager\Windows\SplashWindow.xaml.cs:line 98
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)

```

</p>
</details> 
 

<details><summary>Visual Studio</summary>
<p>

![图片](https://github.com/CadeEvs/FrostyToolsuite/assets/100991210/cb452fc1-e018-48d3-933c-07f7367c5bc2)

Copy Details:
```
System.Collections.Generic.KeyNotFoundException
  HResult=0x80131577
  Message=The given key was not present in the dictionary.
  Source=mscorlib
  StackTrace:
   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Frosty.Core.Config.get_Item(String option, ConfigScope scope, String profile) in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyPlugin\Config.cs:line 242
   at Frosty.Core.Config.Get[T](String option, T defaultValue, ConfigScope scope, String profile) in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyPlugin\Config.cs:line 215
   at FrostyModManager.Windows.SplashWindow.<Window_Loaded>d__1.MoveNext() in E:\source\repos\fork\FrostyToolsuite\FrostyToolsuite_Legacy\FrostyModManager\Windows\SplashWindow.xaml.cs:line 98
```
</p>
</details> 
